### PR TITLE
BLUEBUTTON-468: Fix deploy log permissions

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -84,7 +84,7 @@ public <V> V insideAnsibleContainer(Closure<V> body) {
 		// Prepend the specified closure with some needed in-container setup.
 		def bodyWithSetup = {
 			// Debug UID/GID.
-			sh 'whoami'
+			//sh 'whoami'
 			sh 'id'
 			sh 'cat /etc/passwd'
 			sh 'touch foobar.txt'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,7 @@ public <V> V insideAnsibleContainer(Closure<V> body) {
 			//sh 'whoami'
 			sh 'id'
 			sh 'cat /etc/passwd'
-			sh 'cat /etc/groups'
+			//sh 'cat /etc/groups'
 			sh 'cat /etc/sudoers'
 			sh 'which sudo'
 			sh 'touch foobar.txt'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,7 +87,9 @@ public <V> V insideAnsibleContainer(Closure<V> body) {
 			//sh 'whoami'
 			sh 'id'
 			sh 'cat /etc/passwd'
+			sh 'cat /etc/groups'
 			sh 'cat /etc/sudoers'
+			sh 'which sudo'
 			sh 'touch foobar.txt'
 
 			// Copy the SSH config and keys and fix permissions.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -101,10 +101,10 @@ public <V> V insideAnsibleContainer(Closure<V> body) {
 			// around files owned by root. That's not great anyways, but it gets
 			// particularly annoying because Jenkins can't move/cleanup those files
 			// when it needs to later. So: we fix the ownership here and problem solved.
-			def jenkinsUid = sh 'id --user'
-			def jenkinsGid = sh 'id --group'
+			def jenkinsUid = sh(script: 'id --user', returnStdout: true).trim()
+			def jenkinsGid = sh(script: 'id --group', returnStdout: true).trim()
 			ansibleRunner.inside(dockerArgs, {
-				sh "chown --recursive $jenkinsUid:$jenkinsGid ."
+				sh "chown --recursive ${jenkinsUid}:${jenkinsGid} ."
 			})
 		}
 	}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -88,7 +88,7 @@ public <V> V insideAnsibleContainer(Closure<V> body) {
 			sh 'id'
 			sh 'cat /etc/passwd'
 			//sh 'cat /etc/groups'
-			sh 'cat /etc/sudoers'
+			//sh 'cat /etc/sudoers'
 			sh 'which sudo'
 			sh 'touch foobar.txt'
 

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,7 +104,7 @@ public <V> V insideAnsibleContainer(Closure<V> body) {
 			def jenkinsUid = sh(script: 'id --user', returnStdout: true).trim()
 			def jenkinsGid = sh(script: 'id --group', returnStdout: true).trim()
 			ansibleRunner.inside(dockerArgs, {
-				sh "chown --recursive ${jenkinsUid}:${jenkinsGid} ."
+				sh "find . -writable -exec chown ${jenkinsUid}:${jenkinsGid} '{}' \;"
 			})
 		}
 	}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -87,6 +87,7 @@ public <V> V insideAnsibleContainer(Closure<V> body) {
 			//sh 'whoami'
 			sh 'id'
 			sh 'cat /etc/passwd'
+			sh 'cat /etc/sudoers'
 			sh 'touch foobar.txt'
 
 			// Copy the SSH config and keys and fix permissions.

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -104,7 +104,7 @@ public <V> V insideAnsibleContainer(Closure<V> body) {
 			def jenkinsUid = sh(script: 'id --user', returnStdout: true).trim()
 			def jenkinsGid = sh(script: 'id --group', returnStdout: true).trim()
 			ansibleRunner.inside(dockerArgs, {
-				sh "find . -writable -exec chown ${jenkinsUid}:${jenkinsGid} '{}' \;"
+				sh "find . -writable -exec chown ${jenkinsUid}:${jenkinsGid} '{}' \\;"
 			})
 		}
 	}

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,7 @@ public <V> V insideAnsibleContainer(Closure<V> body) {
 
 		// Run the container as root, not as the random unbound user that
 		// Jenkins defaults to (as that will cause Python/Ansible errors).
-		def dockerArgs = '-u root:root'
+		def dockerArgs = '-u jenkins:docker'
 
 		// Ensure that Ansible uses Jenkins' SSH config and keys.
 		dockerArgs += ' --volume=/var/lib/jenkins/.ssh:/root/.ssh_jenkins:ro'

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -69,7 +69,7 @@ public <V> V insideAnsibleContainer(Closure<V> body) {
 
 		// Run the container as root, not as the random unbound user that
 		// Jenkins defaults to (as that will cause Python/Ansible errors).
-		def dockerArgs = '-u jenkins:docker'
+		def dockerArgs = ''
 
 		// Ensure that Ansible uses Jenkins' SSH config and keys.
 		dockerArgs += ' --volume=/var/lib/jenkins/.ssh:/root/.ssh_jenkins:ro'
@@ -83,6 +83,12 @@ public <V> V insideAnsibleContainer(Closure<V> body) {
 
 		// Prepend the specified closure with some needed in-container setup.
 		def bodyWithSetup = {
+			// Debug UID/GID.
+			sh 'whoami'
+			sh 'id'
+			sh 'cat /etc/passwd'
+			sh 'touch foobar.txt'
+
 			// Copy the SSH config and keys and fix permissions.
 			sh 'cp --recursive --no-target-directory /root/.ssh_jenkins /root/.ssh'
 			sh 'chmod -R u=rw,g=,o= /root/.ssh'


### PR DESCRIPTION
This one is a bit complex to explain:
1. By default, Jenkins runs Docker containers with the Jenkins UID & GID.
2. Those Docker containers don't have `/etc/passwd` or `/etc/groups` entries for that UID & GID.
    * And they can't, because 1) If we're running as the Jenkins UID, it doesn't have root access inside the container, and 2) because we can't run the `docker build` on Jenkins (for other reasons), we can't add the entries.
3. To workaround the above, we run the Docker container as `root`: it's (obviously) going to have `/etc/passwd` and `/etc/group` entries and it's (obviously) going to have root permissions inside the container.
4. But due to that workaround, any files created in the Jenkins workspace by the Docker container end up owned by `root`:`root` -- which makes Jenkins sad, because it can't clean things up like it wants to.

Took a million tries, but finally came up with a simple enough fix: leverage Docker's root access to fix up the permissions. (Hat tip to @msnook for the general idea, which I shamelessly stole.)

https://jira.cms.gov/browse/BLUEBUTTON-468