### PR TITLE
BLUEBUTTON-670: Fix the EC2 instance types and related config

### DIFF
--- a/backend.yml
+++ b/backend.yml
@@ -31,9 +31,9 @@
         data_pipeline_dir: '/u01/bluebutton-data-pipeline'
         data_pipeline_appjar_name: "bluebutton-data-pipeline-app-{{ data_pipeline_version }}-capsule-fat.jar"
         data_pipeline_appjar_localpath: "~/.m2/repository/gov/hhs/cms/bluebutton/data/pipeline/bluebutton-data-pipeline-app/{{ data_pipeline_version }}"
-        #data_pipeline_jvm_args: (see group_vars/env_*/main.yml)
+        data_pipeline_jvm_args: "-Xmx{{ ((data_pipeline_ec2_instance_type_mem_mib | int) * 0.80) | int }}m"
         data_pipeline_tmp_dir: "{{ data_pipeline_dir }}/tmp"
-        #data_pipeline_loader_threads: (see group_vars/env_*/main.yml)
+        data_pipeline_loader_threads: "{{ data_pipeline_ec2_instance_type_vcpu * 50 }}"
         data_pipeline_user: "{{ vault_data_pipeline_user }}"
         data_pipeline_s3_bucket: "{{ vault_data_pipeline_s3_bucket }}"
         data_pipeline_hicn_hash_iterations: "{{ vault_data_pipeline_hicn_hash_iterations }}"
@@ -58,7 +58,7 @@
         data_server_appserver_service: jboss
         data_server_appserver_installer_name: 'will_not_be_used'  # The JBoss instance used here is already (manually) installed.
         data_server_appserver_local_dir: 'will_not_be_used'  # The JBoss instance used here is already (manually) installed.
-        data_server_appserver_jvmargs: '-Xmx8g -XX:MaxMetaspaceSize=2g'
+        data_server_appserver_jvmargs: "-Xmx{{ (((data_server_ec2_vinstance_type_mem_mib | int) * 0.80) - 2048) | int }}m -XX:MaxMetaspaceSize=2048m"
         data_server_appserver_management_port: "{{ vault_data_server_appserver_management_port }}"
         data_server_appserver_management_username: "{{ vault_data_server_appserver_management_username }}"
         data_server_appserver_management_password: "{{ vault_data_server_appserver_management_password }}"

--- a/group_vars/env_dpr/main.yml
+++ b/group_vars/env_dpr/main.yml
@@ -1,12 +1,14 @@
 ---
-# This system is an m4.large (2 vCPUs, 8 GB RAM)
-data_pipeline_jvm_args: '-Xmx6g'
-# Any more threads than this, and the test Data Pipeline server will eventually crash.
-data_pipeline_loader_threads: 100
+# This system is an m4.large (2 vCPUs, 8 GB RAM).
+data_pipeline_ec2_instance_type_mem_mib: "{{ 8 * 1024 }}"
+data_pipeline_ec2_instance_type_vcpu: 2
 
 # There is no ongoing data refresh here: if we're loading data in the developer preview environment, it should be an initial
 # load.
 data_pipeline_idempotency_required: false
+
+# These systems are m4.xlarge (4 vCPUs, 16 GB RAM).
+data_server_ec2_instance_type_mem_mib: "{{ 16 * 1024 }}"
 
 # The path (in this project) to the test keypair that will be copied to the Data Servers for local-only testing.
 # Note: This file is encrypted with Ansible Vault and will be automagically encrypted during the copy.

--- a/group_vars/env_prod/main.yml
+++ b/group_vars/env_prod/main.yml
@@ -1,8 +1,12 @@
 ---
-# This system is an m4.2xlarge (8 vCPUs, 32 GB RAM)
-data_pipeline_jvm_args: '-Xmx24g'
-data_pipeline_loader_threads: 200
+# This system is an m4.2xlarge (8 vCPUs, 32 GB RAM).
+data_pipeline_ec2_instance_type_mem_mib: "{{ 32 * 1024 }}"
+data_pipeline_ec2_instance_type_vcpu: 8
+
 data_pipeline_idempotency_required: true
+
+# These systems are m4.xlarge (4 vCPUs, 16 GB RAM).
+data_server_ec2_instance_type_mem_mib: "{{ 16 * 1024 }}"
 
 # The path (in this project) to the test keypair that will be copied to the Data Servers for local-only testing.
 # Note: This file is encrypted with Ansible Vault and will be automagically encrypted during the copy.

--- a/group_vars/env_test/main.yml
+++ b/group_vars/env_test/main.yml
@@ -1,13 +1,14 @@
 ---
-# This system is an m4.large (2 vCPUs, 8 GB RAM)
-# But temporarily (2018-10-17) it's an m4.2xlarge (8 vCPUs, 32 GB RAM)
-data_pipeline_jvm_args: '-Xmx24g'
-# Any more threads than this, and the test Data Pipeline server will eventually crash.
-data_pipeline_loader_threads: 200
+# This system is an m4.2xlarge (8 vCPUs, 32 GB RAM).
+data_pipeline_ec2_instance_type_mem_mib: "{{ 32 * 1024 }}"
+data_pipeline_ec2_instance_type_vcpu: 8
 
 # There is no ongoing data refresh here: if we're loading data in test, it should be an initial
 # load.
 data_pipeline_idempotency_required: false
+
+# These systems are m4.large (2 vCPUs, 8 GB RAM).
+data_server_ec2_instance_type_mem_mib: "{{ 8 * 1024 }}"
 
 # The path (in this project) to the test keypair that will be copied to the Data Servers for local-only testing.
 # Note: This file is encrypted with Ansible Vault and will be automagically encrypted during the copy.


### PR DESCRIPTION
In particular, I had the wrong instance type for the TEST Data Server systems, which was causing intermittent crashes.

In general, though, I'm trying to switch things up here to be more automagical: we just specify in the environment variable files what the EC2 instances have _total_, and then math our way to the correct Java configs.

It might take a bit to tweak the functions to be ideal, but should be less fiddly after that.

https://jira.cms.gov/browse/BLUEBUTTON-670