### PR TITLE
BLUEBUTTON-787: Upgrade ansible to latest (from 2.4.1.0 to 2.7.8)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@
 # broken. Run this command first to upgrade it:
 #     $ pip install --upgrade setuptools
 # Reference: https://github.com/ansible/ansible/issues/31741#issuecomment-336889622
-ansible==2.4.1.0
+ansible==2.7.8
 cryptography
 pycrypto
 awscli

--- a/roles/builds_apache/tasks/install_and_configure.yml
+++ b/roles/builds_apache/tasks/install_and_configure.yml
@@ -5,12 +5,11 @@
 
 - name: Install Apache
   yum:
-    name: "{{ item }}"
+    name:
+      - httpd
+      - mod_ssl
     state: present
   become: true
-  with_items:
-    - httpd
-    - mod_ssl
 
 # FIXME: Replace with a HealthAPT/GDIT CA-signed cert, once available.
 - name: Generate SSL Key and Self-Signed Certificate

--- a/roles/builds_jenkins/tasks/config.yml
+++ b/roles/builds_jenkins/tasks/config.yml
@@ -11,7 +11,7 @@
     password: "{{ jenkins_dynamic_admin_password | default(omit) }}"
     script: "{{ lookup('template', 'templates/configure_security.groovy.j2') }}"
   register: jenkins_script_security
-  changed_when: "(jenkins_script_security | success) and 'Changed' in jenkins_script_security.output"
+  changed_when: "(jenkins_script_security is success) and 'Changed' in jenkins_script_security.output"
 
 - name: Configure File Provider Plugin
   jenkins_script:
@@ -20,7 +20,7 @@
     password: "{{ jenkins_dynamic_admin_password | default(omit) }}"
     script: "{{ lookup('template', 'templates/configureFileProvider.groovy.j2') }}"
   register: jenkins_script_file_provider
-  changed_when: "(jenkins_script_file_provider | success) and 'Changed' in jenkins_script_file_provider.output"
+  changed_when: "(jenkins_script_file_provider is success) and 'Changed' in jenkins_script_file_provider.output"
 
 - name: Configure GitHub Settings
   jenkins_script:
@@ -29,7 +29,7 @@
     password: "{{ jenkins_dynamic_admin_password | default(omit) }}"
     script: "{{ lookup('template', 'templates/configureGitHub.groovy.j2') }}"
   register: jenkins_script_github
-  changed_when: "(jenkins_script_github | success) and 'Changed' in jenkins_script_github.output"
+  changed_when: "(jenkins_script_github is success) and 'Changed' in jenkins_script_github.output"
 
 # This keypair was created per the instructions here:
 # <http://central.sonatype.org/pages/working-with-pgp-signatures.html>.

--- a/roles/builds_jenkins/tasks/install.yml
+++ b/roles/builds_jenkins/tasks/install.yml
@@ -5,10 +5,9 @@
 
 - name: Install Pre-requisites
   yum:
-    name: "{{ item }}"
-  with_items:
-    # The `-devel` variant is the JDK (instead of just the JRE).
-    - java-1.8.0-openjdk-devel
+    name:
+      # The `-devel` variant is the JDK (instead of just the JRE).
+      - java-1.8.0-openjdk-devel
   become: true
   notify:
     - "Restart Service 'jenkins'"

--- a/roles/builds_jenkins/tasks/jobs.yml
+++ b/roles/builds_jenkins/tasks/jobs.yml
@@ -32,4 +32,4 @@
     password: "{{ jenkins_dynamic_admin_password | default(omit) }}"
     script: "{{ lookup('template', 'templates/configureJobs.groovy.j2') }}"
   register: jenkins_script_jobs
-  changed_when: "(jenkins_script_jobs | success) and 'Changed' in jenkins_script_jobs.output"
+  changed_when: "(jenkins_script_jobs is success) and 'Changed' in jenkins_script_jobs.output"


### PR DESCRIPTION
Reasoning:

1. It's good to stay current.
2. This was required for the work done in a forthcoming PR; there were some bugs in our previous version of Ansible that couldn't be worked around.

https://jira.cms.gov/browse/BLUEBUTTON-787