### PR TITLE
BLUEBUTTON-816: Workaround udevadm timeouts

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -24,6 +24,13 @@ log_path = ./logs/ansible.log
 # Reference: http://stackoverflow.com/a/29132716/1851299
 callback_whitelist = profile_tasks
 
+# Workaround for `udevadm info --query property --name /dev/x...` timeouts we're seeing.
+# References:
+# * <https://jira.cms.gov/browse/BLUEBUTTON-816>
+# * <https://github.com/ansible/ansible/issues/43884>
+# * Per <https://github.com/ansible/ansible/pull/49398>, may not be a problem in Ansible releases after 2019-01-23.
+gather_timeout = 30
+
 [ssh_connection]
 # Significantly speeds up Ansible processing. Note: RHEL 7 systems have 
 # `requiretty` enabled by default, which will prevent this from working until


### PR DESCRIPTION
This workaround taken from here: <https://github.com/ansible/ansible/issues/43884#issuecomment-419650710>.

https://jira.cms.gov/browse/BLUEBUTTON-816