### PR TITLE
BLUEBUTTON-935: Add db scripts

### DIFF
--- a/dev/db_devops/fhirdb_database_tables_dumps.sh
+++ b/dev/db_devops/fhirdb_database_tables_dumps.sh
@@ -1,0 +1,75 @@
+#! /bin/bash
+#################################################
+# fhirdb_database_tables_dumps.sh
+# This is to run pg_dump for all tables in the public schema
+# This script sends email with a summary report of the table dumps and the upload to S3.
+# Created by Jo Kumedzro
+# Create Date: 15/09/2017
+# modified Date: 12/07/2018
+################################################
+
+# *********************************************#
+typeset var ME=/tmp/fhirdb_database_tables_dumps.lock
+# Check if this script is currently running
+# *********************************************#
+if [ -f $ME ] ; then
+   # the lock file already exists, so what to do?
+   if [ "$(ps -p `cat $ME` | wc -l)" -gt 1 ]; then
+      # Process is still running
+      echo "$0: quit at start: Scripts already running `cat $ME`"
+      exit 0
+   else
+     # process not running, but lock file not deleted?
+     echo " $0: orphan lock file warning. lock file deleted."
+     rm $ME
+   fi
+fi
+## create lock file and traps
+echo $$ > $ME
+chmod 777 $ME
+trap 'rm -f "$ME" >/dev/null 2>&1' 0
+trap "exit 2" 1 2 3 15
+##**********************************************#
+export PGPASSFILE=/var/lib/pgsql/scripts/.pgpass
+export today_dir=`date +%F`
+export file_date=$(date +%Y%m%d |sed 's/://g')
+export script_home=/var/lib/pgsql/scripts/pg_dumps/fhirdb
+export BACKUP_REPORT_OUT=/var/lib/pgsql/scripts/pg_dumps/out/BACKUP_$file_date.RPT
+export S3_BACKUP_LIST=/var/lib/pgsql/scripts/pg_dumps/out/S3_BACKUP_LIST_$file_date.RPT
+export BK_STARTING=/var/lib/pgsql/scripts/bk_starting.txt
+
+## Change to script_home
+cd $script_home
+## Generate the report
+psql -s -d fhirdb <<SQL
+\o fhirdb_database_tables_dumps_t1.dat
+select '/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh '|| tablename ||' > /var/lib/pgsql/scripts/logs/'||tablename||'.log 2>&1 &'
+from pg_tables where schemaname='public' and tablename not like 'hfj_%' AND tablename not like 'trm_%';
+\q
+SQL
+## remove headings
+cat fhirdb_database_tables_dumps_t1.dat |grep "pg_dump_fhir_tables.sh" > fhirdb_database_tables_dumps_t2.dat
+
+## prepare final script
+echo "export today_dir=`date +%F`" > /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_new.sh
+echo "export file_date=$(date +%Y%m%d |sed 's/://g')" >> /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_new.sh
+echo "export BACKUP_REPORT_OUT=/var/lib/pgsql/scripts/pg_dumps/out/BACKUP_$file_date.RPT" >> /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_new.sh
+echo "export S3_BACKUP_LIST=/var/lib/pgsql/scripts/pg_dumps/out/S3_BACKUP_LIST_$file_date.RPT" >> /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_new.sh
+echo "export BK_STARTING=/var/lib/pgsql/scripts/bk_starting.txt" >> /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_new.sh
+echo "export email_list=/var/lib/pgsql/scripts/dba_email_list" >> /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_new.sh
+echo "mailx -s \""AWS-FHIR-PROD: STARTING PG_DUMP BACKUP OF TABLES\"" \`cat \$email_list\`  < \$BK_STARTING" >> /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_new.sh
+cat fhirdb_database_tables_dumps_t2.dat >> /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_new.sh
+echo "wait" >> /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_new.sh
+echo "/opt/backups/db_backup.bash $today_dir" >> /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_new.sh
+echo "/opt/backups/db_list.bash $today_dir > \$S3_BACKUP_LIST" >> /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_new.sh
+echo "echo \"\"  >> \$BACKUP_REPORT_OUT" >> /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_new.sh
+echo "echo \"***************************\"  >> \$BACKUP_REPORT_OUT" >> /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_new.sh
+echo "echo \"BACKUP FILES UPLOADED TO S3\"  >> \$BACKUP_REPORT_OUT" >> /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_new.sh
+echo "echo \"***************************\"  >> \$BACKUP_REPORT_OUT" >> /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_new.sh
+echo "cat \$S3_BACKUP_LIST >> \$BACKUP_REPORT_OUT" >> /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_new.sh
+echo "mailx -s \""AWS-FHIR-PROD: PG_DUMP BACKUP OF TABLES REPORT - COMPLETE\"" \`cat \$email_list\`  < \$BACKUP_REPORT_OUT" >> /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_new.sh
+echo "find /u01/backups/fhirdb/ -mtime +5 -name "20*" -exec rm -rf {} \;" >> /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_new.sh
+sed 's/^ *//' /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_new.sh > /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_tabs_$file_date.sh
+## run the script /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_tabs_$file_date.sh
+chmod 700 /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_tabs_$file_date.sh
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_pg_dump_all_tabs_$file_date.sh  > /var/lib/pgsql/scripts/logs/fhirdb_pg_dump_all_tabs_$file_date.log 2>&1

--- a/dev/db_devops/fhirdb_pg_dump_all_tabs_20190514.sh.example.sh
+++ b/dev/db_devops/fhirdb_pg_dump_all_tabs_20190514.sh.example.sh
@@ -1,0 +1,37 @@
+export today_dir=2019-05-14
+export file_date=20190514
+export BACKUP_REPORT_OUT=/var/lib/pgsql/scripts/pg_dumps/out/BACKUP_20190514.RPT
+export S3_BACKUP_LIST=/var/lib/pgsql/scripts/pg_dumps/out/S3_BACKUP_LIST_20190514.RPT
+export BK_STARTING=/var/lib/pgsql/scripts/bk_starting.txt
+export email_list=/var/lib/pgsql/scripts/dba_email_list
+mailx -s "AWS-FHIR-PROD: STARTING PG_DUMP BACKUP OF TABLES" `cat $email_list`  < $BK_STARTING
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh Beneficiaries > /var/lib/pgsql/scripts/logs/Beneficiaries.log 2>&1 &
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh BeneficiariesHistory > /var/lib/pgsql/scripts/logs/BeneficiariesHistory.log 2>&1 &
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh MedicareBeneficiaryIdHistory > /var/lib/pgsql/scripts/logs/MedicareBeneficiaryIdHistory.log 2>&1 &
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh BeneficiariesHistoryTemp > /var/lib/pgsql/scripts/logs/BeneficiariesHistoryTemp.log 2>&1 &
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh DMEClaimLines > /var/lib/pgsql/scripts/logs/DMEClaimLines.log 2>&1 &
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh OutpatientClaimLines > /var/lib/pgsql/scripts/logs/OutpatientClaimLines.log 2>&1 &
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh SNFClaimLines > /var/lib/pgsql/scripts/logs/SNFClaimLines.log 2>&1 &
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh DMEClaims > /var/lib/pgsql/scripts/logs/DMEClaims.log 2>&1 &
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh OutpatientClaims > /var/lib/pgsql/scripts/logs/OutpatientClaims.log 2>&1 &
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh SNFClaims > /var/lib/pgsql/scripts/logs/SNFClaims.log 2>&1 &
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh schema_version > /var/lib/pgsql/scripts/logs/schema_version.log 2>&1 &
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh HospiceClaimLines > /var/lib/pgsql/scripts/logs/HospiceClaimLines.log 2>&1 &
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh HHAClaims > /var/lib/pgsql/scripts/logs/HHAClaims.log 2>&1 &
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh PartDEvents > /var/lib/pgsql/scripts/logs/PartDEvents.log 2>&1 &
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh HHAClaimLines > /var/lib/pgsql/scripts/logs/HHAClaimLines.log 2>&1 &
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh CarrierClaimLines > /var/lib/pgsql/scripts/logs/CarrierClaimLines.log 2>&1 &
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh InpatientClaimLines > /var/lib/pgsql/scripts/logs/InpatientClaimLines.log 2>&1 &
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh CarrierClaims > /var/lib/pgsql/scripts/logs/CarrierClaims.log 2>&1 &
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh HospiceClaims > /var/lib/pgsql/scripts/logs/HospiceClaims.log 2>&1 &
+/var/lib/pgsql/scripts/pg_dumps/fhirdb/pg_dump_fhir_tables.sh InpatientClaims > /var/lib/pgsql/scripts/logs/InpatientClaims.log 2>&1 &
+wait
+/opt/backups/db_backup.bash 2019-05-14
+/opt/backups/db_list.bash 2019-05-14 > $S3_BACKUP_LIST
+echo ""  >> $BACKUP_REPORT_OUT
+echo "***************************"  >> $BACKUP_REPORT_OUT
+echo "BACKUP FILES UPLOADED TO S3"  >> $BACKUP_REPORT_OUT
+echo "***************************"  >> $BACKUP_REPORT_OUT
+cat $S3_BACKUP_LIST >> $BACKUP_REPORT_OUT
+mailx -s "AWS-FHIR-PROD: PG_DUMP BACKUP OF TABLES REPORT - COMPLETE" `cat $email_list`  < $BACKUP_REPORT_OUT
+find /u01/backups/fhirdb/ -mtime +5 -name 20* -exec rm -rf {} \;

--- a/dev/db_devops/pg_dump_fhir_tables.sh
+++ b/dev/db_devops/pg_dump_fhir_tables.sh
@@ -1,0 +1,55 @@
+#! /bin/bash
+#################################################
+# FHIRDB TABLE PG_DUMP pg_dump_fhir_tables.sh  Scripts
+# This script run pg_dump for a table
+# It sends email to DBAs only
+# Parameter is the table_name to pg_dump
+# Created by Jo Kumedzro
+# Create Date: 09/15/2017
+# Modified Date: 07/12/2018
+# Usage: pg_dump_fhir_tables.sh <table_name>
+################################################
+# *********************************************#
+. /var/lib/pgsql/.bash_profile
+export TABNAME=$1
+export HNAME=`hostname`
+export scripts=/u01/scripts
+export PGPASSFILE=/var/lib/pgsql/scripts/.pgpass
+export script_logs=/u01/scripts/logs
+export JOBTIME=/var/lib/pgsql/scripts/pg_dumps/out/$TABNAME.out
+export dba_email_list=/var/lib/pgsql/scripts/jo_email_list.txt
+
+export today=`date +%F`
+mkdir -p /u01/backups/fhirdb/$today
+dumpfile=/u01/backups/fhirdb/$today/tbl_$TABNAME.dmp
+echo "***************************************" > $JOBTIME
+echo "TABLE: " $TABNAME >> $JOBTIME
+echo "***************************************" >> $JOBTIME
+echo 'DUMP FILE: ' $dumpfile >> $JOBTIME
+echo "" >>$JOBTIME
+echo 'START TIME: ' `date`  >> $JOBTIME
+echo "" >>$JOBTIME
+pg_dump -Fc fhirdb -h localhost -U gditdba --table public.\"$TABNAME\" -b > $dumpfile
+pg_dump_status=$?
+echo 'END TIME: ' `date`  >> $JOBTIME
+
+bsize='0'
+## email output
+if [ -s $dumpfile ] || [ $pg_dump_status -eq 0 ] ; then
+  bk_status='SUCCESSFUL'
+  bsize=`ls -l $dumpfile | awk '{print $5}'`
+else
+  bk_status='FAILURE'
+fi
+echo ""  >> $JOBTIME
+echo 'DUMP FILE SIZE IN BYTES: ' $bsize  >> $JOBTIME
+echo ""  >> $JOBTIME
+echo "JOB STATUS: " $bk_status >> $JOBTIME
+echo ""  >> $JOBTIME
+mailx -s "AWS-FHIR: PG_DUMP Backup Of $TABNAME Table $bk_status" `cat $dba_email_list` < $JOBTIME
+## spool to backup report file
+cat $JOBTIME >> $BACKUP_REPORT_OUT
+## cleanup
+find /var/lib/pgsql/scripts/pg_dumps/out/ -name "*.out" -mtime +30 -exec rm -rf {} \;
+find /var/lib/pgsql/scripts/pg_dumps/out/ -name "*.RPT" -mtime +30 -exec rm -rf {} \;
+find /u01/backups/fhirdb/ -mtime +90 -name "20*" -exec rm -rf {} \;

--- a/dev/db_devops/readme.md
+++ b/dev/db_devops/readme.md
@@ -1,6 +1,6 @@
-# DevOps db manager scripts
+# DB scripts
 
-## Weekly PG_DUMP scripts
+## Weekly PG_DUMP Scripts
 1. `weekly_pg_dump_backup_schedule.txt`
    This is the Unix Cron Schedule
    It runs every Tuesday at 5pm EST
@@ -11,11 +11,16 @@
    This is to ensure that new tables added to the database are backup without editing script.
 
 3. `pg_dump_fhir_tables.sh`
-   This is the script that actually runs the pg_dump. 
-   It takes a table name as parameter
+   This is the script that actually runs the pg_dump. It takes a table name as parameter
    
 4. `fhirdb_pg_dump_all_tabs_20190514.sh`
    This is the script that has been generated for May 14, 2019.
-   It runs all the pg_dump concurrently.
-   It waits until all pg_dump are done, upload to AW S3 and sent a report out to a distribution list.
+   It runs all the pg_dump concurrently, so they can complete in a reasonable time. It waits until all pg_dump are done, upload to AW S3 and sent a report out to a distribution list.
    
+## PG_RESTORE scripts
+
+*ToDo*
+
+## Replica Promote Scripts
+
+*ToDo*

--- a/dev/db_devops/readme.md
+++ b/dev/db_devops/readme.md
@@ -17,10 +17,10 @@
    This is the script that has been generated for May 14, 2019.
    It runs all the pg_dump concurrently, so they can complete in a reasonable time. It waits until all pg_dump are done, upload to AW S3 and sent a report out to a distribution list.
    
-## PG_RESTORE scripts
+## PG_RESTORE Scripts
 
-*ToDo*
+*TODO*
 
 ## Replica Promote Scripts
 
-*ToDo*
+*TODO*

--- a/dev/db_devops/readme.md
+++ b/dev/db_devops/readme.md
@@ -1,0 +1,21 @@
+# DevOps db manager scripts
+
+## Weekly PG_DUMP scripts
+1. `weekly_pg_dump_backup_schedule.txt`
+   This is the Unix Cron Schedule
+   It runs every Tuesday at 5pm EST
+   It runs for over 24 hours
+   
+2. `fhirdb_database_tables_dumps.sh`
+   This script generates the pg_dump run script (e.g. fhirdb_pg_dump_all_tabs_20190514.sh) for all tables in the PUBLIC schema.
+   This is to ensure that new tables added to the database are backup without editing script.
+
+3. `pg_dump_fhir_tables.sh`
+   This is the script that actually runs the pg_dump. 
+   It takes a table name as parameter
+   
+4. `fhirdb_pg_dump_all_tabs_20190514.sh`
+   This is the script that has been generated for May 14, 2019.
+   It runs all the pg_dump concurrently.
+   It waits until all pg_dump are done, upload to AW S3 and sent a report out to a distribution list.
+   

--- a/dev/db_devops/weekly_pg_dump_backup_schedule.txt
+++ b/dev/db_devops/weekly_pg_dump_backup_schedule.txt
@@ -1,0 +1,3 @@
+-bash-4.2$ crontab -l |grep pg_dump
+## weekly pg_dump backups of fhirdb tables
+00 17 * * 2 /var/lib/pgsql/scripts/pg_dumps/fhirdb/fhirdb_database_tables_dumps.sh  > /var/lib/pgsql/scripts/logs/fhirdb_database_tables_dumps.log 2>&1


### PR DESCRIPTION
**Why**
In the spirit of infrastructure as code and dev-ops, all operational scripts should be checked in.

**Changes**
These are Jo's current scripts to dump the database. This location was discussed with @karlmdavis. 

**Next**
Will be adding the scripts to upload to S3, do a pg_restore, and finally to promote replica to a master db. 