### PR TITLE
BLUEBUTTON-1032: Data Server access log parsing and analysis toolkit

### DIFF
--- a/dev/data-server-access-log-analysis/.gitignore
+++ b/dev/data-server-access-log-analysis/.gitignore
@@ -1,0 +1,9 @@
+# Don't commit DBs: they have PII & PHI!
+**/*.sqlite
+**/*.sqlite3
+**/*.db
+
+# Don't commit reports: they can be re-generated, as needed.
+**/*.csv
+**/*.xlsx
+**/*.hgram

--- a/dev/data-server-access-log-analysis/Pipfile
+++ b/dev/data-server-access-log-analysis/Pipfile
@@ -1,0 +1,15 @@
+[[source]]
+name = "pypi"
+url = "https://pypi.org/simple"
+verify_ssl = true
+
+[dev-packages]
+
+[packages]
+boto3 = "*"
+awscli = "*"
+docopt = "*"
+maya = "*"
+
+[requires]
+python_version = "3.7"

--- a/dev/data-server-access-log-analysis/Pipfile.lock
+++ b/dev/data-server-access-log-analysis/Pipfile.lock
@@ -1,0 +1,209 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "4b7438d074afa7c205991efa630ed339e468367f2a21fb240fb3b9fb8fe2b8f3"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.7"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "awscli": {
+            "hashes": [
+                "sha256:9cab21e0bbec93bba94c4bd9dcea204696c3337ecc57ef3c87eac48d6145255b",
+                "sha256:ae7c874d7fbc3bcfd844442381abf9db5eb186295d8df0a7e2a207b41fefa3e3"
+            ],
+            "index": "pypi",
+            "version": "==1.16.189"
+        },
+        "boto3": {
+            "hashes": [
+                "sha256:031fc6b43f7132941d71fa012c404ae10d4ad6191c97580cad7f43619fb5505e",
+                "sha256:b1db8ea71b676c08c07d52a44b0b03007fc922b7618bab8c79f6fd638334bf68"
+            ],
+            "index": "pypi",
+            "version": "==1.9.179"
+        },
+        "botocore": {
+            "hashes": [
+                "sha256:0bcab3d6ee49f348169fe93744feae09aae1445f1e0cb1109caccbec487fbeb0",
+                "sha256:adbc569149432143a0d6f578c0a16417a24f7a579116d086d5cecbb70d848ddb"
+            ],
+            "version": "==1.12.179"
+        },
+        "colorama": {
+            "hashes": [
+                "sha256:463f8483208e921368c9f306094eb6f725c6ca42b0f97e313cb5d5512459feda",
+                "sha256:48eb22f4f8461b1df5734a074b57042430fb06e1d61bd1e11b078c0fe6d7a1f1"
+            ],
+            "version": "==0.3.9"
+        },
+        "dateparser": {
+            "hashes": [
+                "sha256:42d51be54e74a8e80a4d76d1fa6e4edd997098fce24ad2d94a2eab5ef247193e",
+                "sha256:78124c458c461ea7198faa3c038f6381f37588b84bb42740e91a4cbd260b1d09"
+            ],
+            "version": "==0.7.1"
+        },
+        "docopt": {
+            "hashes": [
+                "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
+            ],
+            "index": "pypi",
+            "version": "==0.6.2"
+        },
+        "docutils": {
+            "hashes": [
+                "sha256:02aec4bd92ab067f6ff27a38a38a41173bf01bed8f89157768c1573f53e474a6",
+                "sha256:51e64ef2ebfb29cae1faa133b3710143496eca21c530f3f71424d77687764274",
+                "sha256:7a4bd47eaf6596e1295ecb11361139febe29b084a87bf005bf899f9a42edc3c6"
+            ],
+            "version": "==0.14"
+        },
+        "humanize": {
+            "hashes": [
+                "sha256:a43f57115831ac7c70de098e6ac46ac13be00d69abbf60bdcac251344785bb19"
+            ],
+            "version": "==0.5.1"
+        },
+        "jmespath": {
+            "hashes": [
+                "sha256:3720a4b1bd659dd2eecad0666459b9788813e032b83e7ba58578e48254e0a0e6",
+                "sha256:bde2aef6f44302dfb30320115b17d030798de8c4110e28d5cf6cf91a7a31074c"
+            ],
+            "version": "==0.9.4"
+        },
+        "maya": {
+            "hashes": [
+                "sha256:7f53e06d5a123613dce7c270cbc647643a6942590dba7a19ec36194d0338c3f4",
+                "sha256:fa90d8c6c9a730a7f740dec6e1c7d3da8ca10159e40bb843e4e72772f5e3a9a3"
+            ],
+            "index": "pypi",
+            "version": "==0.6.1"
+        },
+        "pendulum": {
+            "hashes": [
+                "sha256:0f43d963b27e92b04047ce8352e4c277db99f20d0b513df7d0ceafe674a2f727",
+                "sha256:14e60d26d7400980123dbb6e3f2a90b70d7c18c63742ffe5bd6d6a643f8c6ef1",
+                "sha256:5035a4e17504814a679f138374269cc7cc514aeac7ba6d9dc020abc224f25dbc",
+                "sha256:8c0b3d655c1e9205d4dacf42fffc929cde3b19b5fb544a7f7561e6896eb8a000",
+                "sha256:bfc7b33ae193a204ec0bec12ad0d2d3300cd7e51d91d992da525ba3b28f0d265",
+                "sha256:cd70b75800439794e1ad8dbfa24838845e171918df81fa98b68d0d5a6f9b8bf2",
+                "sha256:cf535d36c063575d4752af36df928882b2e0e31541b4482c97d63752785f9fcb"
+            ],
+            "version": "==2.0.4"
+        },
+        "pyasn1": {
+            "hashes": [
+                "sha256:da2420fe13a9452d8ae97a0e478adde1dee153b11ba832a95b223a2ba01c10f7",
+                "sha256:da6b43a8c9ae93bc80e2739efb38cc776ba74a886e3e9318d65fe81a8b8a2c6e"
+            ],
+            "version": "==0.4.5"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:7e6584c74aeed623791615e26efd690f29817a27c73085b78e4bad02493df2fb",
+                "sha256:c89805f6f4d64db21ed966fda138f8a5ed7a4fdbc1a8ee329ce1b74e3c74da9e"
+            ],
+            "markers": "python_version >= '2.7'",
+            "version": "==2.8.0"
+        },
+        "pytz": {
+            "hashes": [
+                "sha256:303879e36b721603cc54604edcac9d20401bdbe31e1e4fdee5b9f98d5d31dfda",
+                "sha256:d747dd3d23d77ef44c6a3526e274af6efeb0a6f1afd5a69ba4d5be4098c8e141"
+            ],
+            "version": "==2019.1"
+        },
+        "pytzdata": {
+            "hashes": [
+                "sha256:778db26940e38cf6547d6574f49375570f7d697970461de531c56cf8400958a3",
+                "sha256:f0469062f799c66480fcc7eae69a8270dc83f0e6522c0e70db882d6bd708d378"
+            ],
+            "version": "==2019.1"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:1adecc22f88d38052fb787d959f003811ca858b799590a5eaa70e63dca50308c",
+                "sha256:436bc774ecf7c103814098159fbb84c2715d25980175292c648f2da143909f95",
+                "sha256:460a5a4248763f6f37ea225d19d5c205677d8d525f6a83357ca622ed541830c2",
+                "sha256:5a22a9c84653debfbf198d02fe592c176ea548cccce47553f35f466e15cf2fd4",
+                "sha256:7a5d3f26b89d688db27822343dfa25c599627bc92093e788956372285c6298ad",
+                "sha256:9372b04a02080752d9e6f990179a4ab840227c6e2ce15b95e1278456664cf2ba",
+                "sha256:a5dcbebee834eaddf3fa7366316b880ff4062e4bcc9787b78c7fbb4a26ff2dd1",
+                "sha256:aee5bab92a176e7cd034e57f46e9df9a9862a71f8f37cad167c6fc74c65f5b4e",
+                "sha256:c51f642898c0bacd335fc119da60baae0824f2cde95b0330b56c0553439f0673",
+                "sha256:c68ea4d3ba1705da1e0d85da6684ac657912679a649e8868bd850d2c299cce13",
+                "sha256:e23d0cc5299223dcc37885dae624f382297717e459ea24053709675a976a3e19"
+            ],
+            "markers": "python_version != '2.6'",
+            "version": "==5.1"
+        },
+        "regex": {
+            "hashes": [
+                "sha256:1c70ccb8bf4ded0cbe53092e9f56dcc9d6b0efcf6e80b6ef9b0ece8a557d6635",
+                "sha256:2948310c01535ccb29bb600dd033b07b91f36e471953889b7f3a1e66b39d0c19",
+                "sha256:2ab13db0411cb308aa590d33c909ea4efeced40188d8a4a7d3d5970657fe73bc",
+                "sha256:38e6486c7e14683cd1b17a4218760f0ea4c015633cf1b06f7c190fb882a51ba7",
+                "sha256:80dde4ff10b73b823da451687363cac93dd3549e059d2dc19b72a02d048ba5aa",
+                "sha256:84daedefaa56320765e9c4d43912226d324ef3cc929f4d75fa95f8c579a08211",
+                "sha256:b98e5876ca1e63b41c4aa38d7d5cc04a736415d4e240e9ae7ebc4f780083c7d5",
+                "sha256:ca4f47131af28ef168ff7c80d4b4cad019cb4cabb5fa26143f43aa3dbd60389c",
+                "sha256:cf7838110d3052d359da527372666429b9485ab739286aa1a11ed482f037a88c",
+                "sha256:dd4e8924915fa748e128864352875d3d0be5f4597ab1b1d475988b8e3da10dd7",
+                "sha256:f2c65530255e4010a5029eb11138f5ecd5aa70363f57a3444d83b3253b0891be"
+            ],
+            "version": "==2019.6.8"
+        },
+        "rsa": {
+            "hashes": [
+                "sha256:25df4e10c263fb88b5ace923dd84bf9aa7f5019687b5e55382ffcdb8bede9db5",
+                "sha256:43f682fea81c452c98d09fc316aae12de6d30c4b5c84226642cf8f8fd1c93abd"
+            ],
+            "version": "==3.4.2"
+        },
+        "s3transfer": {
+            "hashes": [
+                "sha256:6efc926738a3cd576c2a79725fed9afde92378aa5c6a957e3af010cb019fac9d",
+                "sha256:b780f2411b824cb541dbcd2c713d0cb61c7d1bcadae204cdddda2b35cef493ba"
+            ],
+            "version": "==0.2.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:3350809f0555b11f552448330d0b52d5f24c91a322ea4a15ef22629740f3761c",
+                "sha256:d16a0141ec1a18405cd4ce8b4613101da75da0e9a7aec5bdd4fa804d0e0eba73"
+            ],
+            "version": "==1.12.0"
+        },
+        "snaptime": {
+            "hashes": [
+                "sha256:e3f1eb89043d58d30721ab98cb65023f1a4c2740e3b197704298b163c92d508b"
+            ],
+            "version": "==0.2.4"
+        },
+        "tzlocal": {
+            "hashes": [
+                "sha256:4ebeb848845ac898da6519b9b31879cf13b6626f7184c496037b818e238f2c4e"
+            ],
+            "version": "==1.5.1"
+        },
+        "urllib3": {
+            "hashes": [
+                "sha256:b246607a25ac80bedac05c6f282e3cdaf3afb65420fd024ac94435cabe6e18d1",
+                "sha256:dbe59173209418ae49d485b87d1681aefa36252ee85884c31346debd19463232"
+            ],
+            "markers": "python_version >= '3.4'",
+            "version": "==1.25.3"
+        }
+    },
+    "develop": {}
+}

--- a/dev/data-server-access-log-analysis/README.md
+++ b/dev/data-server-access-log-analysis/README.md
@@ -1,0 +1,107 @@
+# Data Server Access Log Analysis
+
+This is basically a junk drawer of "random scripts we've cobbled together to help analyze our access logs".
+Many or most of these bits & pieces will (hopefully) eventually be converted into Splunk reports.
+Until then, though, this is what we use when analyzing the performance of the Data Server in production.
+
+### `access_logs_db_build.sh`
+
+Copies down all of our access logs, parses them, and imports them into a local SQLite DB.
+Takes something like 4 hours to run?
+I don't remember exactly, but basically: start it before going to sleep.
+
+Run it as follows:
+
+    $ cd dev/data-server-access-log-analysis
+    $ ./access_logs_db_build.sh
+
+This will produce a `./output/access_logs.sqlite` DB file.
+See below for details on interesting things you can do with that DB.
+
+Uses the following scripts as helpers:
+
+* `access_logs_db_create_or_update.sh`:
+  (see below)
+* `access_logs_parse_to_csv.awk.sh`:
+  (see below)
+* `print_log_events.py`:
+  Not currently used, but will eventually be needed.
+  Can pull the access logs from CloudWatch, instead of via `scp`, like `access_logs_db_build.sh` currently does.
+  This is slower, but will work once we switch to auto-scaling.
+  It can be run as follows:
+      
+      ```
+      pipenv run ./print_log_events.py pd_jboss_access --start 2019-06-26
+      ```
+      
+
+### `access_logs_db_create_or_update.sh`
+
+Creates (or updates) the SQLite DB used for analysis.
+This database can be opened for interactive querying, as follows:
+
+    $ /usr/local/opt/sqlite3/bin/sqlite3 ./output/access_logs.sqlite
+    sqlite> SELECT count(*) FROM access_log_extra WHERE timestamp LIKE '20%';
+    count(*)
+    ----------
+    35982651
+    Run Time: real 86.138 user 7.291287 sys 9.794020
+    sqlite> .quit
+
+Has a bunch of different views, most of which were failed attempts at getting SQLite to perform percentile analysis.
+I think I finally got that working with the `access_log_percentiles_monthly4` view, which bins all queries by request type and month, and reports on various response duration percentiles.
+For example, the following query returns all percentiles for all query types:
+
+    $ /usr/local/opt/sqlite3/bin/sqlite3 -csv -header \
+        ./output/access_logs.sqlite \
+        "SELECT * FROM access_log_percentiles_monthly4"
+
+It will take about 21 minutes to run (on my box) and return output like the following:
+
+```
+month,request_operation_type,count,duration_milliseconds_p25_index,duration_milliseconds_p25,duration_milliseconds_p50_index,duration_milliseconds_p50,duration_milliseconds_p75_index,duration_milliseconds_p75,duration_milliseconds_p90_index,duration_milliseconds_p90,duration_milliseconds_p99_index,duration_milliseconds_p99,duration_milliseconds_p999_index,duration_milliseconds_p999,duration_milliseconds_p100_index,duration_milliseconds_p100
+...
+2019-05,NULL,1,1,NULL,1,NULL,1,NULL,1,NULL,1,NULL,1,NULL,1,NULL
+2019-05,coverage_by_patient_id,1897,474,3,948,5,1422,9,1707,12,1878,78,1895,219,1897,240
+2019-05,eob_by_patient_id_all,170940,42735,496,85470,785,128205,1355,153846,2182,169230,4522,170769,14069,170940,1135139
+2019-05,metadata,2612178,653044,0,1306089,0,1959133,0,2350960,0,2586056,1,2609565,1,2612178,2241
+2019-05,patient_by_id,29008,7252,4,14504,6,21756,9,26107,12,28717,35,28978,156,29008,8004
+2019-05,patient_by_identifier,7274,1818,6,3637,9,5455,12,6546,21,7201,13201,7266,13680,7274,293289
+...
+```
+
+I later added the `access_log_percentiles_hourly` view, which is bascially the same thing as `access_log_percentiles_monthly4`, except binned by hour.
+
+#### Other Queries
+
+Here's a bunch of other random queries & commands that I see in my SQLite history, which may be useful:
+
+    sqlite> .timer on
+    sqlite> .mode column
+    sqlite> .headers on
+    sqlite> .separator ROW "\n"
+    sqlite> .nullvalue NULL
+    sqlite> SELECT * FROM access_log_percentiles_monthly4 WHERE request_operation_type = 'eob_by_patient_id_all';
+    sqlite> SELECT avg(bytes), max(bytes) FROM access_log_extra WHERE request_operation_type = 'eob_by_patient_id_all';
+    sqlite> SELECT avg(bytes), max(bytes) FROM access_log_extra WHERE request_operation_type = 'eob_by_patient_id_all' AND timestamp LIKE '2018-12%';
+    sqlite> SELECT count(*) FROM access_log_extra WHERE request_operation_type = 'eob_by_patient_id_all';
+    sqlite> SELECT duration_milliseconds, bytes FROM access_log_extra WHERE request_operation_type = 'eob_by_patient_id_all' AND timestamp LIKE '2019-05%';
+
+### `access_logs_parse_to_csv.awk.sh`
+
+This Gawk script (note: definitely requires GNU AWK; not "regular" AWK) parses our Wildfly/JBoss access log format and converts it to CSV.
+This is used by `access_logs_db_build.sh` to get our access logs into SQLite.
+
+It may also be useful in the future (with some tweaking) to convert our current access logs to JSON,
+  if that's ever something we need to do.
+
+### `hgram_ifier.groovy`
+
+This simple Groovy script reads in response durations (in milliseconds, one value per line)
+  and outputs an HGRAM of their distribution, using the most excellent
+  <https://github.com/HdrHistogram/HdrHistogram> library.
+
+See the comment at the top of this script for more details,
+  but this has quickly become my primary tool for answering the question
+  "are we meeting our SLOs, and if not, how far do we have to go?"
+HDR histograms are really a **fantastic** analysis tool!

--- a/dev/data-server-access-log-analysis/README.md
+++ b/dev/data-server-access-log-analysis/README.md
@@ -83,9 +83,9 @@ Here's a bunch of other random queries & commands that I see in my SQLite histor
     sqlite> .nullvalue NULL
     sqlite> SELECT * FROM access_log_percentiles_monthly4 WHERE request_operation_type = 'eob_by_patient_id_all';
     sqlite> SELECT avg(bytes), max(bytes) FROM access_log_extra WHERE request_operation_type = 'eob_by_patient_id_all';
-    sqlite> SELECT avg(bytes), max(bytes) FROM access_log_extra WHERE request_operation_type = 'eob_by_patient_id_all' AND timestamp LIKE '2018-12%';
+    sqlite> SELECT avg(bytes), max(bytes) FROM access_log_extra WHERE request_operation_type = 'eob_by_patient_id_all' AND timestamp_month = '2018-12';
     sqlite> SELECT count(*) FROM access_log_extra WHERE request_operation_type = 'eob_by_patient_id_all';
-    sqlite> SELECT duration_milliseconds, bytes FROM access_log_extra WHERE request_operation_type = 'eob_by_patient_id_all' AND timestamp LIKE '2019-05%';
+    sqlite> SELECT duration_milliseconds, bytes FROM access_log_extra WHERE request_operation_type = 'eob_by_patient_id_all' AND timestamp_month = '2019-05';
 
 ### `access_logs_parse_to_csv.awk.sh`
 

--- a/dev/data-server-access-log-analysis/access_logs_db_build.sh
+++ b/dev/data-server-access-log-analysis/access_logs_db_build.sh
@@ -1,0 +1,73 @@
+#!/bin/sh
+
+set -e
+set -o pipefail
+
+csvPipe='/tmp/data-server-access-log.csv'
+sqliteDb='./output/access_logs.sqlite'
+
+importCsvToSqlite() {
+  mkfifo "${csvPipe}"
+
+"${sqlite3}" "${sqliteDb}" <<EOF &
+.mode csv
+.headers off
+.import "${csvPipe}" access_log
+EOF
+
+  cat - > "${csvPipe}"
+  wait
+  rm "${csvPipe}"
+}
+
+parseToCsv() {
+  "${gawk}" -f ./access_logs_parse_to_csv.awk "localHostname=${localHostname}" | importCsvToSqlite
+}
+
+buildDatabaseViaSsh() {
+  localHostname='pdcw10ap01'
+  ssh -q bluebutton-healthapt-prod-data-server-a-1 "cat /u01/jboss/jboss-eap-7.0/standalone/log/access*" | parseToCsv
+
+  localHostname='pdcw10ap02'
+  ssh -q bluebutton-healthapt-prod-data-server-b-1 "cat /u01/jboss/jboss-eap-7.0/standalone/log/access*" | parseToCsv
+}
+
+createSqliteDb() {
+  if [ -f "${sqliteDb}" ]; then
+    >&2 echo "Database file '${sqliteDb}' already exists. Aborting."
+    exit 1
+  else
+    ./access_logs_db_create_or_update.sh "${sqliteDb}"
+  fi
+}
+
+findSqlite3() {
+  sqlite3Homebrew='/usr/local/opt/sqlite/bin/sqlite3'
+  if [ -x "${sqlite3Homebrew}" ]; then
+    echo "${sqlite3Homebrew}"
+  else
+    echo 'sqlite3'
+  fi
+}
+sqlite3="$(findSqlite3)"
+
+findGawk() {
+  gawkHomebrew='/usr/local/opt/gawk/bin/gawk'
+  if [ -x "${gawkHomebrew}" ]; then
+    echo "${gawkHomebrew}"
+  else
+    echo 'gawk'
+  fi
+}
+gawk="$(findGawk)"
+
+createSqliteDb
+buildDatabaseViaSsh
+
+echo "Access logs retrieved, parsed, and imported to DB: '${sqliteDb}'"
+echo "  Total Records: $("${sqlite3}" "${sqliteDb}" "SELECT count(*) FROM access_log")"
+echo "   First Record: $("${sqlite3}" "${sqliteDb}" "SELECT min(timestamp) FROM access_log WHERE timestamp LIKE '20%'")"
+echo "    Last Record: $("${sqlite3}" "${sqliteDb}" "SELECT max(timestamp) FROM access_log")"
+
+# Exit normally (don't trip the error handler).
+trap - EXIT

--- a/dev/data-server-access-log-analysis/access_logs_db_create_or_update.sh
+++ b/dev/data-server-access-log-analysis/access_logs_db_create_or_update.sh
@@ -1,0 +1,712 @@
+#!/bin/sh
+
+# Check to see if we are running in Cygwin.
+uname="$(uname 2>/dev/null)"
+if [ -z "${uname}" ]; then uname="$(/usr/bin/uname 2>/dev/null)"; fi
+if [ -z "${uname}" ]; then echo "Unable to find uname." >&2; exit 1; fi
+case "${uname}" in
+	CYGWIN*) cygwin=true ;;
+	*) cygwin=false ;;
+esac
+
+# In Cygwin, some of the args will have unescaped backslashes. Fix that.
+if [ "${cygwin}" = true ]; then
+	set -- "$(printf '%s' "${@}" | sed -e '/\\/\\\\/g')"
+fi
+
+# Verify that all required options were specified.
+if [ -z "${1}" ]; then >&2 echo 'Specify the DB file to create.'; exit 1; fi
+targetDb="${1}"
+
+# In Cygwin, some of those paths will come in as Windows-formatted. Fix that.
+if [ "${cygwin}" = true ]; then
+	targetDb="$(cygpath --unix "${targetDb}")"
+fi
+
+# Verify that the target DB doesn't already exist.
+if [ -f "${targetDb}" ]; then
+	echo >&2 "Target DB already exists."
+	exit 1
+fi
+
+# Exit immediately if something fails.
+set -e
+error() {
+	parent_lineno="$1"
+	message="$2"
+	code="${3:-1}"
+
+	if [ -n "$message" ] ; then
+			>&2 echo "Error on or near line ${parent_lineno} of file $(basename "${0}"): ${message}."
+	else
+			>&2 echo "Error on or near line ${parent_lineno} of file $(basename "${0}")."
+	fi
+
+	>&2 echo "Exiting with status ${code}."
+	exit "${code}"
+}
+trap 'error ${LINENO}' EXIT
+
+findSqlite3() {
+  sqlite3Homebrew='/usr/local/opt/sqlite/bin/sqlite3'
+  if [ -x "${sqlite3Homebrew}" ]; then
+    echo "${sqlite3Homebrew}"
+  else
+    echo 'sqlite3'
+  fi
+}
+
+sqlite3="$(findSqlite3)"
+
+# Create the DB with its schema.
+"${sqlite3}" "${targetDb}" <<EOF
+-- Stores Data Server access log entries.
+CREATE TABLE IF NOT EXISTS access_log (
+	local_host_name TEXT NOT NULL,
+	remote_host_name TEXT NOT NULL,
+	remote_logical_username TEXT,
+	remote_authenticated_user TEXT,
+	timestamp TEXT NOT NULL,
+	request TEXT NOT NULL,
+	query_string TEXT,
+	status_code INTEGER NOT NULL,
+	bytes INTEGER NOT NULL,
+	duration_milliseconds INTEGER NOT NULL,
+	original_query_id TEXT,
+	original_query_counter INTEGER,
+	original_query_timestamp TEXT,
+	developer_id INTEGER,
+	developer_name TEXT,
+	application_id INTEGER,
+	application TEXT,
+	user_id TEXT,
+	user TEXT,
+	beneficiary_id INTEGER
+);
+
+-- Adds helper fields to 'access_log':
+-- * timestamp_month
+-- * timestamp_day
+-- * timestamp_hour
+-- * timestamp_minute
+-- * timestamp_second
+-- * request_operation_type
+DROP VIEW IF EXISTS access_log_extra;
+CREATE VIEW access_log_extra
+	AS
+	SELECT
+		local_host_name,
+		remote_host_name,
+		remote_logical_username,
+		remote_authenticated_user,
+		timestamp,
+		strftime('%Y-%m', timestamp) AS timestamp_month,
+		strftime('%Y-%m-%d', timestamp) AS timestamp_day,
+		strftime('%Y-%m-%dT%H', timestamp) AS timestamp_hour,
+		strftime('%Y-%m-%dT%H:%M', timestamp) AS timestamp_minute,
+		strftime('%Y-%m-%dT%H:%M:%S', timestamp) AS timestamp_second,
+		CASE
+			WHEN request LIKE '%/metadata%' THEN 'metadata'
+			WHEN request LIKE '%/Patient%' AND query_string NOT LIKE '%identifier=%' THEN 'patient_by_id'
+			WHEN request LIKE '%/Patient%' AND query_string LIKE '%identifier=%' THEN 'patient_by_identifier'
+			WHEN request LIKE '%/Coverage%' AND query_string LIKE '%beneficiary=%' THEN 'coverage_by_patient_id'
+			WHEN request LIKE '%/ExplanationOfBenefit%' AND query_string LIKE '%patient=%' AND query_string NOT LIKE '%_count=%' THEN 'eob_by_patient_id_all'
+			WHEN request LIKE '%/ExplanationOfBenefit%' AND query_string LIKE '%patient=%' AND query_string LIKE '%_count=%' THEN 'eob_by_patient_id_paged'
+			ELSE NULL
+		END request_operation_type,
+		request,
+		query_string,
+		status_code,
+		bytes,
+		duration_milliseconds,
+		original_query_id,
+		original_query_counter,
+		original_query_timestamp,
+		developer_id,
+		developer_name,
+		application_id,
+		application,
+		user_id,
+		user,
+		beneficiary_id
+	FROM
+		access_log;
+
+-- Calculates percentile response times for each 'request_operation_type', over all time.
+DROP VIEW IF EXISTS access_log_percentiles_all;
+CREATE VIEW
+	access_log_percentiles_all (
+		request_operation_type,
+		date_range_start,
+		date_range_end,
+		count,
+		duration_milliseconds_p50,
+		duration_milliseconds_p90,
+		duration_milliseconds_p99,
+		duration_milliseconds_p100
+	)
+	AS
+	WITH
+		requests_metadata(timestamp, request_operation_type, duration_milliseconds) AS
+			(SELECT timestamp, request_operation_type, duration_milliseconds FROM access_log_extra WHERE request_operation_type = 'metadata' ORDER BY duration_milliseconds ASC),
+		requests_patient_by_id(timestamp, request_operation_type, duration_milliseconds) AS
+			(SELECT timestamp, request_operation_type, duration_milliseconds FROM access_log_extra WHERE request_operation_type = 'patient_by_id' ORDER BY duration_milliseconds ASC),
+		requests_patient_by_identifier(timestamp, request_operation_type, duration_milliseconds) AS
+			(SELECT timestamp, request_operation_type, duration_milliseconds FROM access_log_extra WHERE request_operation_type = 'patient_by_identifier' ORDER BY duration_milliseconds ASC),
+		requests_coverage_by_patient_id(timestamp, request_operation_type, duration_milliseconds) AS
+			(SELECT timestamp, request_operation_type, duration_milliseconds FROM access_log_extra WHERE request_operation_type = 'coverage_by_patient_id' ORDER BY duration_milliseconds ASC),
+		requests_eob_by_patient_id_all(timestamp, request_operation_type, duration_milliseconds) AS
+			(SELECT timestamp, request_operation_type, duration_milliseconds FROM access_log_extra WHERE request_operation_type = 'eob_by_patient_id_all' ORDER BY duration_milliseconds ASC),
+		requests_eob_by_patient_id_paged(timestamp, request_operation_type, duration_milliseconds) AS
+			(SELECT timestamp, request_operation_type, duration_milliseconds FROM access_log_extra WHERE request_operation_type = 'eob_by_patient_id_paged' ORDER BY duration_milliseconds ASC)
+	SELECT
+			request_operation_type,
+			MIN(timestamp),
+			MAX(timestamp),
+			COUNT(*),
+			(SELECT inner.duration_milliseconds FROM requests_metadata AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_metadata) * 50 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_metadata AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_metadata) * 90 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_metadata AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_metadata) * 99 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_metadata AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_metadata) - 1)
+		FROM requests_metadata
+	UNION ALL
+	SELECT
+			request_operation_type,
+			MIN(timestamp),
+			MAX(timestamp),
+			COUNT(*),
+			(SELECT inner.duration_milliseconds FROM requests_patient_by_id AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_patient_by_id) * 50 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_patient_by_id AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_patient_by_id) * 90 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_patient_by_id AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_patient_by_id) * 99 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_patient_by_id AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_patient_by_id) - 1)
+		FROM requests_patient_by_id
+	UNION ALL
+	SELECT
+			request_operation_type,
+			MIN(timestamp),
+			MAX(timestamp),
+			COUNT(*),
+			(SELECT inner.duration_milliseconds FROM requests_patient_by_identifier AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_patient_by_identifier) * 50 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_patient_by_identifier AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_patient_by_identifier) * 90 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_patient_by_identifier AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_patient_by_identifier) * 99 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_patient_by_identifier AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_patient_by_identifier) - 1)
+		FROM requests_patient_by_identifier
+	UNION ALL
+	SELECT
+			request_operation_type,
+			MIN(timestamp),
+			MAX(timestamp),
+			COUNT(*),
+			(SELECT inner.duration_milliseconds FROM requests_coverage_by_patient_id AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_coverage_by_patient_id) * 50 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_coverage_by_patient_id AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_coverage_by_patient_id) * 90 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_coverage_by_patient_id AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_coverage_by_patient_id) * 99 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_coverage_by_patient_id AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_coverage_by_patient_id) - 1)
+		FROM requests_coverage_by_patient_id
+	UNION ALL
+	SELECT
+			request_operation_type,
+			MIN(timestamp),
+			MAX(timestamp),
+			COUNT(*),
+			(SELECT inner.duration_milliseconds FROM requests_eob_by_patient_id_all AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_eob_by_patient_id_all) * 50 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_eob_by_patient_id_all AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_eob_by_patient_id_all) * 90 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_eob_by_patient_id_all AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_eob_by_patient_id_all) * 99 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_eob_by_patient_id_all AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_eob_by_patient_id_all) - 1)
+		FROM requests_eob_by_patient_id_all
+	UNION ALL
+	SELECT
+			request_operation_type,
+			MIN(timestamp),
+			MAX(timestamp),
+			COUNT(*),
+			(SELECT inner.duration_milliseconds FROM requests_eob_by_patient_id_paged AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_eob_by_patient_id_paged) * 50 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_eob_by_patient_id_paged AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_eob_by_patient_id_paged) * 90 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_eob_by_patient_id_paged AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_eob_by_patient_id_paged) * 99 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_eob_by_patient_id_paged AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_eob_by_patient_id_paged) - 1)
+		FROM requests_eob_by_patient_id_paged;
+
+-- Doesn't work. Not sure why, but SQLite throws odd errors.
+DROP VIEW IF EXISTS access_log_percentiles_monthly;
+CREATE VIEW
+	access_log_percentiles_monthly (
+		request_operation_type,
+		month,
+		count,
+		duration_milliseconds_p50,
+		duration_milliseconds_p90,
+		duration_milliseconds_p99,
+		duration_milliseconds_p100
+	)
+	AS
+	WITH
+		months(month, month_start, month_end) AS
+			(SELECT strftime('%Y-%m', timestamp), date(timestamp, 'start of month'), date(timestamp, 'start of month','+1 month','-1 day') FROM access_log GROUP BY strftime('%Y-%m', timestamp) ORDER BY timestamp ASC),
+		requests_metadata(timestamp, month, request_operation_type, duration_milliseconds) AS
+			(SELECT timestamp, month, request_operation_type, duration_milliseconds FROM access_log_extra INNER JOIN months ON strftime('%Y-%m', access_log_extra.timestamp) = months.month WHERE request_operation_type = 'metadata' ORDER BY duration_milliseconds ASC),
+		requests_eob_by_patient_id(timestamp, month, request_operation_type, duration_milliseconds) AS
+			(SELECT timestamp, month, request_operation_type, duration_milliseconds FROM access_log_extra INNER JOIN months ON strftime('%Y-%m', access_log_extra.timestamp) = months.month WHERE request_operation_type = 'eob_by_patient_id_all' ORDER BY duration_milliseconds ASC)
+	SELECT
+			request_operation_type,
+			month,
+			COUNT(*),
+			(SELECT inner.duration_milliseconds FROM requests_metadata AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_metadata) * 50 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_metadata AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_metadata) * 90 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_metadata AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_metadata) * 99 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_metadata AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_metadata) - 1)
+		FROM requests_metadata
+	UNION ALL
+	SELECT
+			request_operation_type,
+			month,
+			COUNT(*),
+			(SELECT inner.duration_milliseconds FROM requests_eob_by_patient_id AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_eob_by_patient_id) * 50 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_eob_by_patient_id AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_eob_by_patient_id) * 90 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_eob_by_patient_id AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_eob_by_patient_id) * 99 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_eob_by_patient_id AS inner
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_eob_by_patient_id) - 1)
+		FROM requests_eob_by_patient_id;
+
+-- Doesn't work. Not sure why, but SQLite throws odd errors.
+DROP VIEW IF EXISTS access_log_percentiles_monthly2;
+CREATE VIEW
+	access_log_percentiles_monthly2 (
+		request_operation_type,
+		month,
+		count,
+		duration_milliseconds_p50,
+		duration_milliseconds_p90,
+		duration_milliseconds_p99,
+		duration_milliseconds_p100
+	)
+	AS
+	WITH
+		months(month, month_start, month_end) AS
+			(SELECT strftime('%Y-%m', timestamp), date(timestamp, 'start of month'), date(timestamp, 'start of month','+1 month','-1 day') FROM access_log GROUP BY strftime('%Y-%m', timestamp) ORDER BY timestamp ASC),
+		requests_metadata(timestamp, month, request_operation_type, duration_milliseconds) AS
+			(SELECT timestamp, month, request_operation_type, duration_milliseconds FROM access_log_extra INNER JOIN months ON strftime('%Y-%m', access_log_extra.timestamp) = months.month WHERE request_operation_type = 'metadata' ORDER BY duration_milliseconds ASC),
+		requests_patient_by_id(timestamp, month, request_operation_type, duration_milliseconds) AS
+			(SELECT timestamp, month, request_operation_type, duration_milliseconds FROM access_log_extra INNER JOIN months ON strftime('%Y-%m', access_log_extra.timestamp) = months.month WHERE request_operation_type = 'patient_by_id' ORDER BY duration_milliseconds ASC),
+		requests_patient_by_identifier(timestamp, month, request_operation_type, duration_milliseconds) AS
+			(SELECT timestamp, month, request_operation_type, duration_milliseconds FROM access_log_extra INNER JOIN months ON strftime('%Y-%m', access_log_extra.timestamp) = months.month WHERE request_operation_type = 'patient_by_identifier' ORDER BY duration_milliseconds ASC),
+		requests_coverage_by_patient_id(timestamp, month, request_operation_type, duration_milliseconds) AS
+			(SELECT timestamp, month, request_operation_type, duration_milliseconds FROM access_log_extra INNER JOIN months ON strftime('%Y-%m', access_log_extra.timestamp) = months.month WHERE request_operation_type = 'coverage_by_patient_id' ORDER BY duration_milliseconds ASC),
+		requests_eob_by_patient_id_all(timestamp, month, request_operation_type, duration_milliseconds) AS
+			(SELECT timestamp, month, request_operation_type, duration_milliseconds FROM access_log_extra INNER JOIN months ON strftime('%Y-%m', access_log_extra.timestamp) = months.month WHERE request_operation_type = 'eob_by_patient_id_all' ORDER BY duration_milliseconds ASC),
+		requests_eob_by_patient_id_paged(timestamp, month, request_operation_type, duration_milliseconds) AS
+			(SELECT timestamp, month, request_operation_type, duration_milliseconds FROM access_log_extra INNER JOIN months ON strftime('%Y-%m', access_log_extra.timestamp) = months.month WHERE request_operation_type = 'eob_by_patient_id_paged' ORDER BY duration_milliseconds ASC)
+	SELECT
+			request_operation_type,
+			month,
+			COUNT(*),
+			(SELECT inner.duration_milliseconds FROM requests_metadata AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_metadata AS inner WHERE inner.month = month) * 50 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_metadata AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_metadata AS inner WHERE inner.month = month) * 90 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_metadata AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_metadata AS inner WHERE inner.month = month) * 99 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_metadata AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_metadata AS inner WHERE inner.month = month) - 1)
+		FROM requests_metadata AS outer
+		GROUP BY month
+	UNION ALL
+	SELECT
+			request_operation_type,
+			month,
+			COUNT(*),
+			(SELECT inner.duration_milliseconds FROM requests_patient_by_id AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_patient_by_id AS inner WHERE inner.month = month) * 50 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_patient_by_id AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_patient_by_id AS inner WHERE inner.month = month) * 90 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_patient_by_id AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_patient_by_id AS inner WHERE inner.month = month) * 99 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_patient_by_id AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_patient_by_id AS inner WHERE inner.month = month) - 1)
+		FROM requests_patient_by_id AS outer
+		GROUP BY month
+	UNION ALL
+	SELECT
+			request_operation_type,
+			month,
+			COUNT(*),
+			(SELECT inner.duration_milliseconds FROM requests_patient_by_identifier AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_patient_by_identifier AS inner WHERE inner.month = month) * 50 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_patient_by_identifier AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_patient_by_identifier AS inner WHERE inner.month = month) * 90 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_patient_by_identifier AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_patient_by_identifier AS inner WHERE inner.month = month) * 99 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_patient_by_identifier AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_patient_by_identifier AS inner WHERE inner.month = month) - 1)
+		FROM requests_patient_by_identifier AS outer
+		GROUP BY month
+	UNION ALL
+	SELECT
+			request_operation_type,
+			month,
+			COUNT(*),
+			(SELECT inner.duration_milliseconds FROM requests_coverage_by_patient_id AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_coverage_by_patient_id AS inner WHERE inner.month = month) * 50 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_coverage_by_patient_id AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_coverage_by_patient_id AS inner WHERE inner.month = month) * 90 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_coverage_by_patient_id AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_coverage_by_patient_id AS inner WHERE inner.month = month) * 99 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_coverage_by_patient_id AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_coverage_by_patient_id AS inner WHERE inner.month = month) - 1)
+		FROM requests_coverage_by_patient_id AS outer
+		GROUP BY month
+	UNION ALL
+	SELECT
+			request_operation_type,
+			month,
+			COUNT(*),
+			(SELECT inner.duration_milliseconds FROM requests_eob_by_patient_id_all AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_eob_by_patient_id_all AS inner WHERE inner.month = month) * 50 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_eob_by_patient_id_all AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_eob_by_patient_id_all AS inner WHERE inner.month = month) * 90 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_eob_by_patient_id_all AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_eob_by_patient_id_all AS inner WHERE inner.month = month) * 99 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_eob_by_patient_id_all AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_eob_by_patient_id_all AS inner WHERE inner.month = month) - 1)
+		FROM requests_eob_by_patient_id_all AS outer
+		GROUP BY month
+	UNION ALL
+	SELECT
+			request_operation_type,
+			month,
+			COUNT(*),
+			(SELECT inner.duration_milliseconds FROM requests_eob_by_patient_id_paged AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_eob_by_patient_id_paged AS inner WHERE inner.month = month) * 50 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_eob_by_patient_id_paged AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_eob_by_patient_id_paged AS inner WHERE inner.month = month) * 90 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_eob_by_patient_id_paged AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_eob_by_patient_id_paged AS inner WHERE inner.month = month) * 99 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_eob_by_patient_id_paged AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_eob_by_patient_id_paged AS inner WHERE inner.month = month) - 1)
+		FROM requests_eob_by_patient_id_paged AS outer
+		GROUP BY month;
+
+-- Doesn't work. Not sure why, but SQLite throws odd errors.
+DROP VIEW IF EXISTS access_log_percentiles_monthly_for_metadata;
+CREATE VIEW
+	access_log_percentiles_monthly_for_metadata (
+		request_operation_type,
+		month,
+		count,
+		duration_milliseconds_p50,
+		duration_milliseconds_p90,
+		duration_milliseconds_p99,
+		duration_milliseconds_p100
+	)
+	AS
+	WITH
+		months(month, month_start, month_end) AS
+			(SELECT strftime('%Y-%m', timestamp), date(timestamp, 'start of month'), date(timestamp, 'start of month','+1 month','-1 day') FROM access_log GROUP BY strftime('%Y-%m', timestamp) ORDER BY timestamp ASC),
+		requests_metadata(timestamp, month, request_operation_type, duration_milliseconds) AS
+			(SELECT timestamp, month, request_operation_type, duration_milliseconds FROM access_log_extra INNER JOIN months ON strftime('%Y-%m', access_log_extra.timestamp) = months.month WHERE request_operation_type = 'metadata' ORDER BY duration_milliseconds ASC)
+	SELECT
+			request_operation_type,
+			month,
+			COUNT(*),
+			(SELECT inner.duration_milliseconds FROM requests_metadata AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_metadata AS inner WHERE inner.month = month) * 50 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_metadata AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_metadata AS inner WHERE inner.month = month) * 90 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_metadata AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_metadata AS inner WHERE inner.month = month) * 99 / 100 - 1),
+			(SELECT inner.duration_milliseconds FROM requests_metadata AS inner WHERE inner.month = outer.month
+				LIMIT 1 OFFSET (SELECT COUNT(*) FROM requests_metadata AS inner WHERE inner.month = month) - 1)
+		FROM requests_metadata AS outer
+		GROUP BY month;
+
+-- Doesn't work. Not sure why, but SQLite throws odd errors.
+DROP VIEW IF EXISTS access_log_percentiles_monthly_for_eob_by_patient_id_all;
+CREATE VIEW
+	access_log_percentiles_monthly_for_eob_by_patient_id_all (
+		request_operation_type,
+		month,
+		count,
+		duration_milliseconds_p99_index,
+		duration_milliseconds_p99
+	)
+	AS
+	WITH
+		months(month, month_start, month_end) AS
+			(SELECT strftime('%Y-%m', timestamp), date(timestamp, 'start of month'), date(timestamp, 'start of month','+1 month','-1 day') FROM access_log GROUP BY strftime('%Y-%m', timestamp) ORDER BY timestamp ASC),
+		requests_eob_by_patient_id_all(timestamp, month, request_operation_type, duration_milliseconds) AS
+			(SELECT timestamp, month, request_operation_type, duration_milliseconds FROM access_log_extra INNER JOIN months ON strftime('%Y-%m', access_log_extra.timestamp) = months.month WHERE request_operation_type = 'eob_by_patient_id_all' ORDER BY duration_milliseconds ASC)
+	SELECT
+			request_operation_type,
+			month,
+			count(*),
+			count(*) * 99 / 100 - 1,
+			(
+				SELECT
+					duration_milliseconds
+				FROM
+					(
+						SELECT
+							duration_milliseconds,
+							row_number() OVER (ORDER BY duration_milliseconds ASC) AS rn,
+							count(*) OVER (ORDER BY duration_milliseconds ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING) AS rc
+						FROM requests_eob_by_patient_id_all AS inner
+						WHERE
+							inner.month = outer.month
+					)
+				WHERE
+					rn = rc * 99 / 100 - 1
+			)
+		FROM requests_eob_by_patient_id_all AS outer
+		GROUP BY outer.month;
+
+-- Helper view that "bins" access_log_extra entries by 'month' and 'request_operation_type':
+-- each entry within one of those bins gets an index assigned to it, ordered by 'duration_milliseconds'.
+-- This allows for simpler percentile calculations in other views.
+DROP VIEW IF EXISTS access_log_binned;
+CREATE VIEW
+	access_log_binned (
+		month,
+		request_operation_type,
+		duration_milliseconds,
+		bin_index,
+		bin_count
+	)
+	AS
+	SELECT
+		strftime('%Y-%m', timestamp),
+		request_operation_type,
+		duration_milliseconds,
+		row_number() OVER binned_durations,
+		count(*) OVER binned_durations
+	FROM access_log_extra
+	WINDOW binned_durations AS (PARTITION BY timestamp_month, request_operation_type ORDER BY duration_milliseconds ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+	ORDER BY
+		strftime('%Y-%m', timestamp) ASC,
+		request_operation_type ASC,
+		duration_milliseconds ASC;
+
+-- Helper view that "bins" access_log_extra entries by 'hour' and 'request_operation_type':
+-- each entry within one of those bins gets an index assigned to it, ordered by 'duration_milliseconds'.
+-- This allows for simpler percentile calculations in other views.
+DROP VIEW IF EXISTS access_log_binned_hourly;
+CREATE VIEW
+	access_log_binned_hourly (
+		hour,
+		request_operation_type,
+		duration_milliseconds,
+		bin_index,
+		bin_count
+	)
+	AS
+	SELECT
+		strftime('%Y-%m-%dT%H', timestamp),
+		request_operation_type,
+		duration_milliseconds,
+		row_number() OVER binned_durations,
+		count(*) OVER binned_durations
+	FROM access_log_extra
+	WINDOW binned_durations AS (PARTITION BY timestamp_hour, request_operation_type ORDER BY duration_milliseconds ASC ROWS BETWEEN UNBOUNDED PRECEDING AND UNBOUNDED FOLLOWING)
+	ORDER BY
+		strftime('%Y-%m-%dT%H', timestamp) ASC,
+		request_operation_type ASC,
+		duration_milliseconds ASC;
+
+-- Finally have a query that appears to work!
+-- Unfortunately, it runs so slowly that it may never complete.  :-(
+DROP VIEW IF EXISTS access_log_percentiles_monthly3;
+CREATE VIEW
+	access_log_percentiles_monthly3 (
+		request_operation_type,
+		month,
+		count,
+		duration_milliseconds_p25_index,
+		duration_milliseconds_p25,
+		duration_milliseconds_p50_index,
+		duration_milliseconds_p50,
+		duration_milliseconds_p75_index,
+		duration_milliseconds_p75,
+		duration_milliseconds_p90_index,
+		duration_milliseconds_p90,
+		duration_milliseconds_p99_index,
+		duration_milliseconds_p99,
+		duration_milliseconds_p999_index,
+		duration_milliseconds_p999,
+		duration_milliseconds_p100_index,
+		duration_milliseconds_p100
+	)
+	AS
+	SELECT
+		base.month,
+		base.request_operation_type,
+		base.bin_count,
+		max(1, CAST(0.25 * base.bin_count AS int)),
+		p25.duration_milliseconds,
+		max(1, CAST(0.50 * base.bin_count AS int)),
+		p50.duration_milliseconds,
+		max(1, CAST(0.75 * base.bin_count AS int)),
+		p75.duration_milliseconds,
+		max(1, CAST(0.90 * base.bin_count AS int)),
+		p90.duration_milliseconds,
+		max(1, CAST(0.99 * base.bin_count AS int)),
+		p99.duration_milliseconds,
+		max(1, CAST(0.999 * base.bin_count AS int)),
+		p999.duration_milliseconds,
+		base.bin_count,
+		p100.duration_milliseconds
+	FROM access_log_binned AS base
+	LEFT JOIN access_log_binned AS p25 ON p25.month = base.month AND p25.request_operation_type = base.request_operation_type AND base.bin_index = max(1, CAST(0.25 * base.bin_count AS int))
+	LEFT JOIN access_log_binned AS p50 ON p50.month = base.month AND p50.request_operation_type = base.request_operation_type AND base.bin_index = max(1, CAST(0.50 * base.bin_count AS int))
+	LEFT JOIN access_log_binned AS p75 ON p75.month = base.month AND p75.request_operation_type = base.request_operation_type AND base.bin_index = max(1, CAST(0.75 * base.bin_count AS int))
+	LEFT JOIN access_log_binned AS p90 ON p90.month = base.month AND p90.request_operation_type = base.request_operation_type AND base.bin_index = max(1, CAST(0.90 * base.bin_count AS int))
+	LEFT JOIN access_log_binned AS p99 ON p99.month = base.month AND p99.request_operation_type = base.request_operation_type AND base.bin_index = max(1, CAST(0.99 * base.bin_count AS int))
+	LEFT JOIN access_log_binned AS p999 ON p999.month = base.month AND p999.request_operation_type = base.request_operation_type AND base.bin_index = max(1, CAST(0.999 * base.bin_count AS int))
+	LEFT JOIN access_log_binned AS p100 ON p100.month = base.month AND p100.request_operation_type = base.request_operation_type AND base.bin_index = base.bin_count
+	GROUP BY
+		base.request_operation_type,
+		base.month,
+		base.bin_count
+	ORDER BY
+		base.month ASC,
+		base.request_operation_type ASC;
+
+-- Calculates the percentiles of 'duration_milliseconds' for all responses, binned by 'month' + 'request_operation_type'.
+-- Note: This view works! And reasonably quickly! Takes 486 seconds to query it, when run run on pdcw10ap01 with 16993177 access log entries from 2017-10-27 through 2018-12-17.
+DROP VIEW IF EXISTS access_log_percentiles_monthly4;
+CREATE VIEW
+	access_log_percentiles_monthly4 (
+		month,
+		request_operation_type,
+		count,
+		duration_milliseconds_p25_index,
+		duration_milliseconds_p25,
+		duration_milliseconds_p50_index,
+		duration_milliseconds_p50,
+		duration_milliseconds_p75_index,
+		duration_milliseconds_p75,
+		duration_milliseconds_p90_index,
+		duration_milliseconds_p90,
+		duration_milliseconds_p99_index,
+		duration_milliseconds_p99,
+		duration_milliseconds_p999_index,
+		duration_milliseconds_p999,
+		duration_milliseconds_p100_index,
+		duration_milliseconds_p100
+	)
+	AS
+	WITH
+		inner(month, request_operation_type, bin_count) AS
+			(SELECT month, request_operation_type, bin_count FROM access_log_binned GROUP BY month, request_operation_type, bin_count)
+	SELECT
+		inner.month,
+		inner.request_operation_type,
+		inner.bin_count,
+		max(1, CAST(0.25 * inner.bin_count AS int)),
+		max(CASE outer.bin_index WHEN max(1, CAST(0.25 * inner.bin_count AS int)) THEN outer.duration_milliseconds END),
+		max(1, CAST(0.50 * inner.bin_count AS int)),
+		max(CASE outer.bin_index WHEN max(1, CAST(0.50 * inner.bin_count AS int)) THEN outer.duration_milliseconds END),
+		max(1, CAST(0.75 * inner.bin_count AS int)),
+		max(CASE outer.bin_index WHEN max(1, CAST(0.75 * inner.bin_count AS int)) THEN outer.duration_milliseconds END),
+		max(1, CAST(0.90 * inner.bin_count AS int)),
+		max(CASE outer.bin_index WHEN max(1, CAST(0.90 * inner.bin_count AS int)) THEN outer.duration_milliseconds END),
+		max(1, CAST(0.99 * inner.bin_count AS int)),
+		max(CASE outer.bin_index WHEN max(1, CAST(0.99 * inner.bin_count AS int)) THEN outer.duration_milliseconds END),
+		max(1, CAST(0.999 * inner.bin_count AS int)),
+		max(CASE outer.bin_index WHEN max(1, CAST(0.999 * inner.bin_count AS int)) THEN outer.duration_milliseconds END),
+		max(inner.bin_count),
+		max(CASE outer.bin_index WHEN inner.bin_count THEN outer.duration_milliseconds END)
+	FROM inner
+	LEFT JOIN access_log_binned AS outer ON inner.month = outer.month AND inner.request_operation_type = outer.request_operation_type
+	GROUP BY
+		inner.request_operation_type,
+		inner.month,
+		inner.bin_count
+	ORDER BY
+		inner.month ASC,
+		inner.request_operation_type ASC;
+
+-- Calculates the percentiles of 'duration_milliseconds' for all responses, binned by 'hour' + 'request_operation_type'.
+DROP VIEW IF EXISTS access_log_percentiles_hourly;
+CREATE VIEW
+	access_log_percentiles_hourly (
+		hour,
+		request_operation_type,
+		count,
+		duration_milliseconds_p25_index,
+		duration_milliseconds_p25,
+		duration_milliseconds_p50_index,
+		duration_milliseconds_p50,
+		duration_milliseconds_p75_index,
+		duration_milliseconds_p75,
+		duration_milliseconds_p90_index,
+		duration_milliseconds_p90,
+		duration_milliseconds_p99_index,
+		duration_milliseconds_p99,
+		duration_milliseconds_p999_index,
+		duration_milliseconds_p999,
+		duration_milliseconds_p100_index,
+		duration_milliseconds_p100
+	)
+	AS
+	WITH
+		inner(hour, request_operation_type, bin_count) AS
+			(SELECT hour, request_operation_type, bin_count FROM access_log_binned_hourly GROUP BY hour, request_operation_type, bin_count)
+	SELECT
+		inner.hour,
+		inner.request_operation_type,
+		inner.bin_count,
+		max(1, CAST(0.25 * inner.bin_count AS int)),
+		max(CASE outer.bin_index WHEN max(1, CAST(0.25 * inner.bin_count AS int)) THEN outer.duration_milliseconds END),
+		max(1, CAST(0.50 * inner.bin_count AS int)),
+		max(CASE outer.bin_index WHEN max(1, CAST(0.50 * inner.bin_count AS int)) THEN outer.duration_milliseconds END),
+		max(1, CAST(0.75 * inner.bin_count AS int)),
+		max(CASE outer.bin_index WHEN max(1, CAST(0.75 * inner.bin_count AS int)) THEN outer.duration_milliseconds END),
+		max(1, CAST(0.90 * inner.bin_count AS int)),
+		max(CASE outer.bin_index WHEN max(1, CAST(0.90 * inner.bin_count AS int)) THEN outer.duration_milliseconds END),
+		max(1, CAST(0.99 * inner.bin_count AS int)),
+		max(CASE outer.bin_index WHEN max(1, CAST(0.99 * inner.bin_count AS int)) THEN outer.duration_milliseconds END),
+		max(1, CAST(0.999 * inner.bin_count AS int)),
+		max(CASE outer.bin_index WHEN max(1, CAST(0.999 * inner.bin_count AS int)) THEN outer.duration_milliseconds END),
+		max(inner.bin_count),
+		max(CASE outer.bin_index WHEN inner.bin_count THEN outer.duration_milliseconds END)
+	FROM inner
+	LEFT JOIN access_log_binned_hourly AS outer ON inner.hour = outer.hour AND inner.request_operation_type = outer.request_operation_type
+	GROUP BY
+		inner.request_operation_type,
+		inner.hour,
+		inner.bin_count
+	ORDER BY
+		inner.hour ASC,
+		inner.request_operation_type ASC;
+EOF
+
+# Exit normally (don't trip the error handler).
+trap - EXIT

--- a/dev/data-server-access-log-analysis/access_logs_parse_to_csv.awk
+++ b/dev/data-server-access-log-analysis/access_logs_parse_to_csv.awk
@@ -1,0 +1,109 @@
+#! /usr/bin/gawk -f
+
+BEGIN {
+  # Set the field pattern to handle the dumb quoted and bracketed fields thing going on.
+  FPAT = "([^ ]+)|(\"[^\"]+\")|(\\[[^\\]]+\\])"
+
+  # Build a map of short-month-names (e.g. "Jan") to left-padded month-numbers (e.g. "01").
+  split("Jan,Feb,Mar,Apr,May,Jun,Jul,Aug,Sep,Oct,Nov,Dec", monthShortNames, ",")
+  for(monthNum = 1; monthNum <= 12; monthNum++) {
+    monthNumsByShortName[monthShortNames[monthNum]] = sprintf("%02d", monthNum)
+  }
+}
+
+{
+  ##
+  # Assign all of the fields a human friendly name.
+  ##
+  remoteHostname = $1
+  remoteLogicalUsername = $2
+  remoteAuthenticatedUser = $3
+  timestampRaw = $4
+  request = $5
+  queryString = $6
+  statusCode = $7
+  bytes = $8
+  durationMilliseconds = $9
+  originalQueryId = $10
+  originalQueryCounter = $11
+  originalQueryTimestampRaw = $12
+  developerId = $13
+  developerName = $14
+  applicationId = $15
+  applicationName = $16
+  userId = $17
+  userName = $18
+  beneficiaryId = $19
+
+  ##
+  # Parse out the timestamp into its pieces, then glue them back together in ISO 8601 format, e.g. '2018-12-18T03:33:46+00:00'.
+  # Timestamps come in as timestampRaw = '[01/Dec/2018:00:00:04 -0500]'.
+  ##
+
+  # Strip out the leading and trailing bracket.
+  gsub(/\[/, "", timestampRaw)
+  gsub(/\]/, "", timestampRaw)
+
+  # Split by ' ' to break off the timestamp offset at the end.
+  split(timestampRaw, timestampTokensBySpace, " ")
+
+  # Split by ':' to break into combined-date and separate-time tokens.
+  split(timestampTokensBySpace[1], timestampTokensByColon, ":")
+
+  # Split the combined-date into its pieces (by '/').
+  split(timestampTokensByColon[1], dateTokens, "/")
+
+  # Add a colon to the timezone offset (some versions of SQLite require this).
+  timezoneOffsetStart = substr(timestampTokensBySpace[2], 1, 3)
+  timezoneOffsetEnd = substr(timestampTokensBySpace[2], 4)
+
+  # Assign all the pieces.
+  year = dateTokens[3]
+  month = monthNumsByShortName[dateTokens[2]]
+  day = dateTokens[1]
+  hour = timestampTokensByColon[2]
+  minute = timestampTokensByColon[3]
+  second = timestampTokensByColon[4]
+  timezoneOffset = sprintf("%s:%s", timezoneOffsetStart, timezoneOffsetEnd)
+
+  # Combine all the pieces back together correctly.
+  timestamp = sprintf("%s-%s-%sT%s:%s:%s%s", year, month, day, hour, minute, second, timezoneOffset)
+
+  ##
+  # Other miscellaneous data cleaning.
+  ##
+
+  # Remove the leading double-question-mark in the query string.
+  gsub(/^"\?\?/, "?", queryString)
+
+  # Re-format originalQueryTimestampRaw, which comes in looking like "[2018-12-01 05:07:20.370803]" or "[-]", to ISO 8601.
+  gsub(/\[/, "", originalQueryTimestampRaw)
+  gsub(/\]/, "", originalQueryTimestampRaw)
+  originalQueryTimestampTokensCount = split(originalQueryTimestampRaw, originalQueryTimestampTokens, " ")
+  if (originalQueryTimestampTokensCount == 2) {
+    originalQueryTimestamp = sprintf("%sT%sZ", originalQueryTimestampTokens[1], originalQueryTimestampTokens[2])
+  } else {
+    originalQueryTimestamp = ""
+  }
+
+  # Convert "-" to empty fields, where appropriate.
+  gsub(/^-$/, "", remoteLogicalUsername)
+  gsub(/^-$/, "", remoteAuthenticatedUser)
+  gsub(/^-$/, "", originalQueryId)
+  gsub(/^-$/, "", originalQueryCounter)
+  gsub(/^-$/, "", originalQueryTimestamp)
+  gsub(/^-$/, "", developerId)
+  gsub(/^"-"$/, "", developerName)
+  gsub(/^-$/, "", applicationId)
+  gsub(/^"-"$/, "", applicationName)
+  gsub(/^-$/, "", userId)
+  gsub(/^"-"$/, "", userName)
+  gsub(/^-$/, "", beneficiaryId)
+
+  ##
+  # Grand Finale!
+  ##
+
+  # Print out the whole record.
+  printf "%s,%s,%s,%s,%s,%s,%s,%d,%d,%d,%s,%s,%s,%s,%s,%s,%s,%s,%s,%s\n", localHostname, remoteHostname, remoteLogicalUsername, remoteAuthenticatedUser, timestamp, request, queryString, statusCode, bytes, durationMilliseconds, originalQueryId, originalQueryCounter, originalQueryTimestamp, developerId, developerName, applicationId, applicationName, userId, userName, beneficiaryId
+}

--- a/dev/data-server-access-log-analysis/hgram_ifier.groovy
+++ b/dev/data-server-access-log-analysis/hgram_ifier.groovy
@@ -1,0 +1,96 @@
+#!/usr/bin/env groovy
+
+/*
+ * This simple Groovy script reads in response durations (in milliseconds, one
+ * value per line) and outputs an HGRAM of their distribution, using the most
+ * excellent <https://github.com/HdrHistogram/HdrHistogram> library.
+ *
+ * When combined with our SQLite DB of access log entries, it can be run as
+ * follows:
+ *
+ *     $ /usr/local/opt/sqlite3/bin/sqlite3 -csv -noheader \
+ *         ./output/access_logs.sqlite \
+ *         "SELECT duration_milliseconds FROM access_log_extra WHERE request_operation_type = 'eob_by_patient_id_all' AND timestamp_month = '2019-04'" \
+ *         | ./hgram_ifier.groovy \
+ *         > ./output/access_log_durations_eob_by_patient_id_all_201904.hgram
+ *
+ * Or, to create separate HGRAMs for many months all in one go, use a Bash
+ * `for` loop like this:
+ *
+ *     $ time for month in $(/usr/local/opt/sqlite3/bin/sqlite3 -csv -noheader ./output/access_logs.sqlite "SELECT DISTINCT timestamp_month FROM access_log_extra WHERE request_operation_type = 'eob_by_patient_id_all'"); do /usr/local/opt/sqlite3/bin/sqlite3 -csv -noheader ./output/access_logs.sqlite "SELECT duration_milliseconds FROM access_log_extra WHERE request_operation_type = 'eob_by_patient_id_all' AND timestamp_month = '${month}'" | ./hgram_ifier.groovy > "./output/access_log_durations_eob_by_patient_id_all_${month}.hgram"; done
+ *
+ * For easy visualization, take the resulting `.hgram` file and drop it here:
+ * <http://hdrhistogram.github.io/HdrHistogram/plotFiles.html>.
+ */
+
+@Grab(group='org.hdrhistogram', module='HdrHistogram', version='2.1.11')
+import org.HdrHistogram.Histogram;
+
+def cli = new CliBuilder(usage: "${this.class.getSimpleName()}")
+cli.i(required: false, 'input file (defaults to STDIN)')
+cli.o(required: false, 'output file (defaults to STDOUT)')
+cli.h(required: false, longOpt: 'help', 'display this help/usage message')
+
+def options = cli.parse(args)
+if (!options || options.h) {
+	if (!options)
+		System.err << 'Error while parsing command-line options.\n'
+	cli.usage()
+	if (!options)
+		System.exit 1
+}
+
+def inputStream;
+def outputStream;
+try {
+	// Configure input stream.
+	if (options.i) {
+		def inputPath = Paths.get(options.i)
+		if (!Files.isReadable(inputPath)) {
+			System.err << "Unable to read specified input file: '${options.i}'."
+			System.exit 2
+		}
+	
+		inputStream = inputPath.toFile().newInputStream()
+	} else {
+		inputStream = System.in
+	}
+	
+	// Configure output stream.
+	if (options.o) {
+		def outputPath = Paths.get(options.o)
+		if (!Files.isWriteable(outputPath)) {
+			System.err << "Unable to write specified output file: '${options.o}'."
+			System.exit 3
+		}
+	
+		outputStream = outputPath.toFile().newOutputStream()
+	} else {
+		outputStream = System.out
+	}
+
+	// Initialize Histogram: track values from 1 ms to 1 hr (but auto-resizable), at max precision.
+	Histogram histogram = new Histogram(1, 3600000, 5);
+	histogram.setAutoResize(true)
+
+	// Read input line by line, adding each value to histogram.
+	def lineCount = 0;
+	inputStream.eachLine { line ->
+		lineCount++
+		
+		if (!line.isInteger()) {
+			System.err << "Invalid number on line '${lineCount}': '${line.trim}'."
+			System.exit 4
+		}
+		
+        histogram.recordValue(line.toInteger());
+    }
+
+	// Write output HGRAM.
+	histogram.outputPercentileDistribution(outputStream, 1.0);
+} finally {
+	if (inputStream != null)
+		inputStream.close()
+	if (outputStream != null)
+		outputStream.close()
+}

--- a/dev/data-server-access-log-analysis/print_log_events.py
+++ b/dev/data-server-access-log-analysis/print_log_events.py
@@ -1,0 +1,84 @@
+#!/usr/bin/env python
+# -*- encoding: utf-8
+"""Print log event messages from a CloudWatch log group.
+
+Usage: print_log_events.py <LOG_GROUP_NAME> [--start=<START>] [--end=<END>]
+       print_log_events.py -h --help
+
+Options:
+  <LOG_GROUP_NAME>    Name of the CloudWatch log group.
+  --start=<START>     Only print events with a timestamp after this time.
+  --end=<END>         Only print events with a timestamp before this time.
+  -h --help           Show this screen.
+
+"""
+
+import boto3
+import docopt
+import maya
+
+
+def get_log_events(log_group, start_time=None, end_time=None):
+    """Generate all the log events from a CloudWatch group.
+
+    :param log_group: Name of the CloudWatch log group.
+    :param start_time: Only fetch events with a timestamp after this time.
+        Expressed as the number of milliseconds after midnight Jan 1 1970.
+    :param end_time: Only fetch events with a timestamp before this time.
+        Expressed as the number of milliseconds after midnight Jan 1 1970.
+
+    """
+    client = boto3.client('logs')
+    kwargs = {
+        'logGroupName': log_group,
+        'limit': 10000,
+    }
+
+    if start_time is not None:
+        kwargs['startTime'] = start_time
+    if end_time is not None:
+        kwargs['endTime'] = end_time
+
+    while True:
+        resp = client.filter_log_events(**kwargs)
+        yield from resp['events']
+        try:
+            kwargs['nextToken'] = resp['nextToken']
+        except KeyError:
+            break
+
+
+def milliseconds_since_epoch(time_string):
+    dt = maya.when(time_string)
+    seconds = dt.epoch
+    return seconds * 1000
+
+
+if __name__ == '__main__':
+    args = docopt.docopt(__doc__)
+
+    log_group = args['<LOG_GROUP_NAME>']
+
+    if args['--start']:
+        try:
+            start_time = milliseconds_since_epoch(args['--start'])
+        except ValueError:
+            exit(f'Invalid datetime input as --start: {args["--start"]}')
+    else:
+        start_time = None
+
+    if args['--end']:
+        try:
+            end_time = milliseconds_since_epoch(args['--end'])
+        except ValueError:
+            exit(f'Invalid datetime input as --end: {args["--end"]}')
+    else:
+        end_time = None
+
+    logs = get_log_events(
+        log_group=log_group,
+        start_time=start_time,
+        end_time=end_time
+    )
+    for event in logs:
+        print(event['message'].rstrip())


### PR DESCRIPTION
How close or far are we from meeting the SLOs that have been proposed by our various users? Until we have solid performance tests in place, our only way to answer that is by analyzing our past performance, as represented by the Data Server access logs.

Response time SLOs are, most of the time, best specified in terms of percentiles. Rather than saying, "we expect a mean response time of _X_ milliseconds," they should instead be framed as, "we expect that _Y%_ of responses will take less than _Z_ milliseconds. This mirrors the way most end users think about performance: they notice the outliers and care more about consistency than throughput.

(Note that our BCDA friends are a notable exception here: as an asynchronous batch process, they really really care about throughput and so will likely focus more on our mean response time.)

Accordingly, we need ways to measure our performance in percentiles. We've been using CloudWatch for most of our monitoring, but it aggressively discards resolution of old measurements as time marches forward, making its historical percentile data worse than useless. The tools in this PR provide an alternative.

Please see the README for details, but here are a couple of sample outputs produced by all this:

1. Performance of various endpoint operations, over the course of 2019-05:

| month   | request_operation_type | count   | duration_milliseconds_p25 | duration_milliseconds_p50 | duration_milliseconds_p75 | duration_milliseconds_p90 | duration_milliseconds_p99 | duration_milliseconds_p999 | duration_milliseconds_p100 | 
|---------|------------------------|---------|---------------------------|---------------------------|---------------------------|---------------------------|---------------------------|----------------------------|----------------------------| 
| 2019-05 | metadata               | 2612178 | 0                         | 0                         | 0                         | 0                         | 1                         | 1                          | 2241                       | 
| 2019-05 | patient_by_id          | 29008   | 4                         | 6                         | 9                         | 12                        | 35                        | 156                        | 8004                       | 
| 2019-05 | patient_by_identifier  | 7274    | 6                         | 9                         | 12                        | 21                        | 13201                     | 13680                      | 293289                     | 
| 2019-05 | coverage_by_patient_id | 1897    | 3                         | 5                         | 9                         | 12                        | 78                        | 219                        | 240                        | 
| 2019-05 | eob_by_patient_id_all  | 170940  | 496                       | 785                       | 1355                      | 2182                      | 4522                      | 14069                      | 1135139                    | 

2. HDR histogram raw data (see [HdrHistogram: A better latency capture method](http://psy-lob-saw.blogspot.com/2015/02/hdrhistogram-better-latency-capture.html) and [HdrHistogram: A High Dynamic Range Histogram](http://hdrhistogram.org/) for an explanation of HDR histograms), for EOB responses over the course of 2019-05:

```
       Value     Percentile TotalCount 1/(1-Percentile)

    98.00000 0.000000000000          2           1.00
   311.00000 0.100000000000      17243           1.11
   424.00000 0.200000000000      34272           1.25
   530.00000 0.300000000000      51401           1.43
   628.00000 0.400000000000      68435           1.67
   785.00000 0.500000000000      85489           2.00
   876.00000 0.550000000000      94023           2.22
   973.00000 0.600000000000     102625           2.50
  1081.00000 0.650000000000     111117           2.86
  1206.00000 0.700000000000     119663           3.33
  1355.00000 0.750000000000     128246           4.00
  1446.00000 0.775000000000     132495           4.44
  1549.00000 0.800000000000     136758           5.00
  1657.00000 0.825000000000     141026           5.71
  1792.00000 0.850000000000     145323           6.67
  1957.00000 0.875000000000     149577           8.00
  2061.00000 0.887500000000     151718           8.89
  2182.00000 0.900000000000     153855          10.00
  2328.00000 0.912500000000     155994          11.43
  2493.00000 0.925000000000     158126          13.33
  2717.00000 0.937500000000     160259          16.00
  2857.00000 0.943750000000     161327          17.78
  2997.00000 0.950000000000     162398          20.00
  3129.00000 0.956250000000     163462          22.86
  3265.00000 0.962500000000     164534          26.67
  3444.00000 0.968750000000     165604          32.00
  3563.00000 0.971875000000     166133          35.56
  3685.00000 0.975000000000     166671          40.00
  3823.00000 0.978125000000     167201          45.71
  3967.00000 0.981250000000     167739          53.33
  4135.00000 0.984375000000     168271          64.00
  4248.00000 0.985937500000     168538          71.11
  4343.00000 0.987500000000     168805          80.00
  4446.00000 0.989062500000     169071          91.43
  4573.00000 0.990625000000     169339         106.67
  4733.00000 0.992187500000     169605         128.00
  4829.00000 0.992968750000     169741         142.22
  4977.00000 0.993750000000     169872         160.00
  5195.00000 0.994531250000     170006         182.86
  5533.00000 0.995312500000     170139         213.33
  6046.00000 0.996093750000     170273         256.00
  6544.00000 0.996484375000     170340         284.44
  7107.00000 0.996875000000     170406         320.00
  8220.00000 0.997265625000     170473         365.71
  9936.00000 0.997656250000     170540         426.67
 13067.00000 0.998046875000     170607         512.00
 13558.00000 0.998242187500     170640         568.89
 13741.00000 0.998437500000     170674         640.00
 13903.00000 0.998632812500     170708         731.43
 14012.00000 0.998828125000     170740         853.33
 14085.00000 0.999023437500     170774        1024.00
 14118.00000 0.999121093750     170790        1137.78
 14227.00000 0.999218750000     170807        1280.00
 14322.00000 0.999316406250     170824        1462.86
 14412.00000 0.999414062500     170840        1706.67
 14599.00000 0.999511718750     170857        2048.00
 14778.00000 0.999560546875     170865        2275.56
 15006.00000 0.999609375000     170874        2560.00
 15194.00000 0.999658203125     170882        2925.71
 15431.00000 0.999707031250     170890        3413.33
 16056.00000 0.999755859375     170899        4096.00
 16179.00000 0.999780273438     170903        4551.11
 16331.00000 0.999804687500     170907        5120.00
 16776.00000 0.999829101563     170911        5851.43
 17009.00000 0.999853515625     170915        6826.67
 18429.00000 0.999877929688     170920        8192.00
 18705.00000 0.999890136719     170922        9102.22
 19272.00000 0.999902343750     170924       10240.00
 23456.00000 0.999914550781     170926       11702.86
 27804.00000 0.999926757813     170928       13653.33
 29953.00000 0.999938964844     170930       16384.00
 30155.00000 0.999945068359     170931       18204.44
 31357.00000 0.999951171875     170932       20480.00
 31606.00000 0.999957275391     170933       23405.71
 33876.00000 0.999963378906     170934       27306.67
 35760.00000 0.999969482422     170935       32768.00
 36491.00000 0.999972534180     170936       36408.89
 36491.00000 0.999975585938     170936       40960.00
 41920.00000 0.999978637695     170937       46811.43
 41920.00000 0.999981689453     170937       54613.33
 43337.00000 0.999984741211     170938       65536.00
 43337.00000 0.999986267090     170938       72817.78
 43337.00000 0.999987792969     170938       81920.00
327131.00000 0.999989318848     170939       93622.86
327131.00000 0.999990844727     170939      109226.67
327131.00000 0.999992370605     170939      131072.00
327131.00000 0.999993133545     170939      145635.56
327131.00000 0.999993896484     170939      163840.00
1135143.00000 0.999994659424     170940      187245.71
1135143.00000 1.000000000000     170940
#[Mean    =   1103.07520, StdDeviation   =   3064.30288]
#[Max     = 1135143.00000, Total count    =       170940]
#[Buckets =            5, SubBuckets     =       262144]
```

3. HDR histogram chart (courtesy http://hdrhistogram.github.io/HdrHistogram/plotFiles.html), for EOB responses over the course of 2019-05:

<img width="1476" alt="Screen Shot 2019-06-30 at 23 47 49" src="https://user-images.githubusercontent.com/59200/60409756-e15cda00-9b92-11e9-9ba6-6dd8e73e3231.png">

This data all tells an interesting story, namely, that we've got work to do in order to meet those SLOs. But now we know! And as we improve our performance, these analysis tools will help us verify and track that progress.