### PR TITLE
BLUEBUTTON-947: Add missing Data Server and Data Pipeline logs to CloudWatch

### DIFF
--- a/backend.yml
+++ b/backend.yml
@@ -54,6 +54,8 @@
       become: true
       notify:
         - Restart awslogs Service
+  handlers:
+    - import_tasks: handlers/main.yml
 
 - name: Configure Data Server System
   hosts: data_server_systems
@@ -137,6 +139,8 @@
       become: true
       notify:
         - Restart awslogs Service
+  handlers:
+    - import_tasks: handlers/main.yml
 
 - name: Configure Load Balancers
   import_playbook: load_balancers.yml

--- a/backend.yml
+++ b/backend.yml
@@ -44,6 +44,17 @@
         data_pipeline_db_password: "{{ vault_data_pipeline_db_password }}"
         #data_pipeline_idempotency_required: (see group_vars/env_*/main.yml)
 
+    - name: Configure CloudWatch Logs Agent
+      template:
+        src: awslogs.conf.data-pipeline.j2
+        dest: '/var/awslogs/etc/awslogs.conf'
+        owner: root
+        group: root
+        mode: u=rw,g=,o=
+      become: true
+      notify:
+        - Restart awslogs Service
+
 - name: Configure Data Server System
   hosts: data_server_systems
   serial: 1 # only take one Data Server out of rotation at a time

--- a/backend.yml
+++ b/backend.yml
@@ -116,5 +116,16 @@
       delegate_to: localhost
       loop: "{{ ec2_elbs }}"
 
+    - name: Configure CloudWatch Logs Agent
+      template:
+        src: awslogs.conf.data-server.j2
+        dest: '/var/awslogs/etc/awslogs.conf'
+        owner: root
+        group: root
+        mode: u=rw,g=,o=
+      become: true
+      notify:
+        - Restart awslogs Service
+
 - name: Configure Load Balancers
   import_playbook: load_balancers.yml

--- a/group_vars/env_dpr/main.yml
+++ b/group_vars/env_dpr/main.yml
@@ -1,4 +1,10 @@
 ---
+# The abbreviated name for this environment, per the naming conventions used by HealthAPT.
+env_name: 'dp'
+
+# The abbreviated name for this environment, per https://confluence.cms.gov/display/ODI/AWS+Naming+and+Tagging+Conventions.
+env_name_std: 'prod-sbx'
+
 # This system is an m4.large (2 vCPUs, 8 GB RAM).
 data_pipeline_ec2_instance_type_mem_mib: "{{ 8 * 1024 }}"
 data_pipeline_ec2_instance_type_vcpu: 2

--- a/group_vars/env_prod/main.yml
+++ b/group_vars/env_prod/main.yml
@@ -1,4 +1,10 @@
 ---
+# The abbreviated name for this environment, per the naming conventions used by HealthAPT.
+env_name: 'pd'
+
+# The abbreviated name for this environment, per https://confluence.cms.gov/display/ODI/AWS+Naming+and+Tagging+Conventions.
+env_name_std: 'prod'
+
 # This system is an m4.2xlarge (8 vCPUs, 32 GB RAM).
 data_pipeline_ec2_instance_type_mem_mib: "{{ 32 * 1024 }}"
 data_pipeline_ec2_instance_type_vcpu: 8

--- a/group_vars/env_test/main.yml
+++ b/group_vars/env_test/main.yml
@@ -1,4 +1,10 @@
 ---
+# The abbreviated name for this environment, per the naming conventions used by HealthAPT.
+env_name: 'ts'
+
+# The abbreviated name for this environment, per https://confluence.cms.gov/display/ODI/AWS+Naming+and+Tagging+Conventions.
+env_name_std: 'test'
+
 # This system is an m4.2xlarge (8 vCPUs, 32 GB RAM).
 data_pipeline_ec2_instance_type_mem_mib: "{{ 32 * 1024 }}"
 data_pipeline_ec2_instance_type_vcpu: 8

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,0 +1,7 @@
+---
+
+- name: Restart awslogs Service
+  service:
+    name: awslogs
+    state: restarted
+  become: true

--- a/templates/awslogs.conf.data-pipeline.j2
+++ b/templates/awslogs.conf.data-pipeline.j2
@@ -1,0 +1,145 @@
+
+#
+# ------------------------------------------
+# CLOUDWATCH LOGS AGENT CONFIGURATION FILE
+# ------------------------------------------
+#
+# --- DESCRIPTION ---
+# This file is used by the CloudWatch Logs Agent to specify what log data to send to the service and how.
+# You can modify this file at any time to add, remove or change configuration.
+#
+# NOTE: A running agent must be stopped and restarted for configuration changes to take effect.
+#
+# --- CLOUDWATCH LOGS DOCUMENTATION ---
+# https://aws.amazon.com/documentation/cloudwatch/
+#
+# --- CLOUDWATCH LOGS CONSOLE ---
+# https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logs:
+#
+# --- AGENT COMMANDS ---
+# To check or change the running status of the CloudWatch Logs Agent, use the following:
+#
+# To check running status: /etc/init.d/awslogs status
+# To stop the agent: /etc/init.d/awslogs stop
+# To start the agent: /etc/init.d/awslogs start
+#
+# --- AGENT LOG OUTPUT ---
+# You can find logs for the agent in /var/log/awslogs.log
+# You can find logs for the agent script in /var/log/awslogs-agent-setup.log
+#
+
+# ------------------------------------------
+# CONFIGURATION DETAILS
+# ------------------------------------------
+# Refer to http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/AgentReference.html for details.
+
+[general]
+# Path to the CloudWatch Logs agent's state file. The agent uses this file to maintain
+# client side state across its executions.
+state_file = /var/awslogs/state/agent-state
+
+## Each log file is defined in its own section. The section name doesn't
+## matter as long as its unique within this file.
+#[kern.log]
+#
+## Path of log file for the agent to monitor and upload.
+#file = /var/log/kern.log
+#
+## Name of the destination log group.
+#log_group_name = kern.log
+#
+## Name of the destination log stream. You may use {hostname} to use target machine's hostname.
+#log_stream_name = {instance_id} # Defaults to ec2 instance id
+#
+## Format specifier for timestamp parsing. Here are some sample formats:
+## Use '%b %d %H:%M:%S' for syslog (Apr 24 08:38:42)
+## Use '%d/%b/%Y:%H:%M:%S' for apache log (10/Oct/2000:13:55:36)
+## Use '%Y-%m-%d %H:%M:%S' for rails log (2008-09-08 11:52:54)
+#datetime_format = %b %d %H:%M:%S # Specification details in the table below.
+#
+## A batch is buffered for buffer-duration amount of time or 32KB of log events.
+## Defaults to 5000 ms and its minimum value is 5000 ms.
+#buffer_duration = 5000
+#
+# Use 'end_of_file' to start reading from the end of the file.
+# Use 'start_of_file' to start reading from the beginning of the file.
+#initial_position = start_of_file
+#
+## Encoding of file
+#encoding = utf-8 # Other supported encodings include: ascii, latin-1
+#
+#
+#
+# Following table documents the detailed datetime format specification:
+# ----------------------------------------------------------------------------------------------------------------------
+# Directive     Meaning                                                                                 Example
+# ----------------------------------------------------------------------------------------------------------------------
+# %a            Weekday as locale's abbreviated name.                                                   Sun, Mon, ..., Sat (en_US)
+# ----------------------------------------------------------------------------------------------------------------------
+#  %A           Weekday as locale's full name.                                                          Sunday, Monday, ..., Saturday (en_US)
+# ----------------------------------------------------------------------------------------------------------------------
+#  %w           Weekday as a decimal number, where 0 is Sunday and 6 is Saturday.                       0, 1, ..., 6
+# ----------------------------------------------------------------------------------------------------------------------
+#  %d           Day of the month as a zero-padded decimal numbers.                                      01, 02, ..., 31
+# ----------------------------------------------------------------------------------------------------------------------
+#  %b           Month as locale's abbreviated name.                                                     Jan, Feb, ..., Dec (en_US)
+# ----------------------------------------------------------------------------------------------------------------------
+#  %B           Month as locale's full name.                                                            January, February, ..., December (en_US)
+# ----------------------------------------------------------------------------------------------------------------------
+#  %m           Month as a zero-padded decimal number.                                                  01, 02, ..., 12
+# ----------------------------------------------------------------------------------------------------------------------
+#  %y           Year without century as a zero-padded decimal number.                                   00, 01, ..., 99
+# ----------------------------------------------------------------------------------------------------------------------
+#  %Y           Year with century as a decimal number.                                                  1970, 1988, 2001, 2013
+# ----------------------------------------------------------------------------------------------------------------------
+#  %H           Hour (24-hour clock) as a zero-padded decimal number.                                   00, 01, ..., 23
+# ----------------------------------------------------------------------------------------------------------------------
+#  %I           Hour (12-hour clock) as a zero-padded decimal numbers.                                  01, 02, ..., 12
+# ----------------------------------------------------------------------------------------------------------------------
+#  %p           Locale's equivalent of either AM or PM.                                                 AM, PM (en_US)
+# ----------------------------------------------------------------------------------------------------------------------
+#  %M           Minute as a zero-padded decimal number.                                                 00, 01, ..., 59
+# ----------------------------------------------------------------------------------------------------------------------
+#  %S           Second as a zero-padded decimal numbers.                                                00, 01, ..., 59
+# ----------------------------------------------------------------------------------------------------------------------
+#  %f           Microsecond as a decimal number, zero-padded on the left.                               000000, 000001, ..., 999999
+# ----------------------------------------------------------------------------------------------------------------------
+#  %z           UTC offset in the form +HHMM or -HHMM (empty string if the the object is naive).        (empty), +0000, -0400, +1030
+# ----------------------------------------------------------------------------------------------------------------------
+#  %j           Day of the year as a zero-padded decimal number.                                        001, 002, ..., 365
+# ----------------------------------------------------------------------------------------------------------------------
+#  %U           Week number of the year (Sunday as the first day of the week) as a zero padded          00, 01, ..., 53
+#               decimal number. All days in a new year preceding the first Sunday are considered
+#               to be in week 0.
+# ----------------------------------------------------------------------------------------------------------------------
+#  %W           Week number of the year (Monday as the first day of the week) as a decimal number.      00, 01, ..., 53
+#               All days in a new year preceding the first Monday are considered to be in week 0.
+# ----------------------------------------------------------------------------------------------------------------------
+#  %c           Locale's appropriate date and time representation.                                      Tue Aug 16 21:30:00 1988 (en_US)
+# ----------------------------------------------------------------------------------------------------------------------
+
+
+[/var/log/messages]
+datetime_format = %b %d %H:%M:%S
+file = /var/log/messages
+buffer_duration = 5000
+log_stream_name = {instance_id}
+initial_position = end_of_file
+log_group_name = /var/log/messages
+
+[/var/log/secure]
+datetime_format = %b %d %H:%M:%S
+file = /var/log/secure
+buffer_duration = 5000
+log_stream_name = {instance_id}
+initial_position = start_of_file
+log_group_name = /var/log/secure
+
+[bfd_data_pipeline_message_txt]
+datetime_format = %Y-%m-%d %H:%M:%S,%f
+file = /u01/bluebutton-data-pipeline/bluebutton-data-pipeline.log
+buffer_duration = 5000
+log_stream_name = {instance_id}
+initial_position = start_of_file
+log_group_name = /bfd/{{ env_name_std }}/data-pipeline/message.txt
+multi_line_start_pattern = ^[\d\d\d\d-\d\d-\d\d ]

--- a/templates/awslogs.conf.data-server.j2
+++ b/templates/awslogs.conf.data-server.j2
@@ -174,6 +174,7 @@ buffer_duration = 5000
 log_stream_name = {instance_id}
 initial_position = start_of_file
 log_group_name = /bfd/{{ env_name_std }}/data-server/message.txt
+multi_line_start_pattern = ^[\d\d\d\d-\d\d-\d\d ]
 
 [bfs_app_message_ndjson]
 datetime_format = %Y-%m-%dT%H:%M:%S.%f%z
@@ -190,4 +191,4 @@ buffer_duration = 5000
 log_stream_name = {instance_id}
 initial_position = start_of_file
 log_group_name = /bfd/{{ env_name_std }}/data-server/message.json
-multi_line_start_pattern = ^[^\d]
+multi_line_start_pattern = ^[\d\d\d\d-\d\d-\d\dT]

--- a/templates/awslogs.conf.data-server.j2
+++ b/templates/awslogs.conf.data-server.j2
@@ -143,7 +143,7 @@ log_stream_name = {instance_id}
 initial_position = start_of_file
 log_group_name = {{ env_name }}_jboss_access
 
-[jboss_server]
+[bfd_jboss_server]
 datetime_format = %Y-%m-%d %H:%M:%S,%f
 file = /u01/jboss/jboss-eap-7.0/standalone/log/server.log*
 buffer_duration = 5000
@@ -151,7 +151,7 @@ log_stream_name = {instance_id}
 initial_position = start_of_file
 log_group_name = /bfd/{{ env_name_std }}/data-server/access
 
-[bfs_app_access]
+[bfd_data_server_access]
 datetime_format = %Y-%m-%dT%H:%M:%S.%f%z
 file = /u01/jboss/bluebutton-server-app-log-access.json
 buffer_duration = 5000
@@ -159,7 +159,7 @@ log_stream_name = {instance_id}
 initial_position = start_of_file
 log_group_name = /bfd/{{ env_name_std }}/data-server/access
 
-[bfs_app_database_query]
+[bfd_data_server_database_query]
 datetime_format = %Y-%m-%dT%H:%M:%S.%f%z
 file = /u01/jboss/bluebutton-server-app-log-database.json
 buffer_duration = 5000
@@ -167,7 +167,7 @@ log_stream_name = {instance_id}
 initial_position = start_of_file
 log_group_name = /bfd/{{ env_name_std }}/data-server/database
 
-[bfs_app_message_txt]
+[bfd_data_server_message_txt]
 datetime_format = %Y-%m-%d %H:%M:%S,%f
 file = /u01/jboss/bluebutton-server-app.log
 buffer_duration = 5000
@@ -176,7 +176,7 @@ initial_position = start_of_file
 log_group_name = /bfd/{{ env_name_std }}/data-server/message.txt
 multi_line_start_pattern = ^[\d\d\d\d-\d\d-\d\d ]
 
-[bfs_app_message_ndjson]
+[bfd_data_server_message_ndjson]
 datetime_format = %Y-%m-%dT%H:%M:%S.%f%z
 file = /u01/jboss/bluebutton-server-app-log.json
 buffer_duration = 5000

--- a/templates/awslogs.conf.data-server.j2
+++ b/templates/awslogs.conf.data-server.j2
@@ -1,0 +1,193 @@
+
+#
+# ------------------------------------------
+# CLOUDWATCH LOGS AGENT CONFIGURATION FILE
+# ------------------------------------------
+#
+# --- DESCRIPTION ---
+# This file is used by the CloudWatch Logs Agent to specify what log data to send to the service and how.
+# You can modify this file at any time to add, remove or change configuration.
+#
+# NOTE: A running agent must be stopped and restarted for configuration changes to take effect.
+#
+# --- CLOUDWATCH LOGS DOCUMENTATION ---
+# https://aws.amazon.com/documentation/cloudwatch/
+#
+# --- CLOUDWATCH LOGS CONSOLE ---
+# https://console.aws.amazon.com/cloudwatch/home?region=us-east-1#logs:
+#
+# --- AGENT COMMANDS ---
+# To check or change the running status of the CloudWatch Logs Agent, use the following:
+#
+# To check running status: /etc/init.d/awslogs status
+# To stop the agent: /etc/init.d/awslogs stop
+# To start the agent: /etc/init.d/awslogs start
+#
+# --- AGENT LOG OUTPUT ---
+# You can find logs for the agent in /var/log/awslogs.log
+# You can find logs for the agent script in /var/log/awslogs-agent-setup.log
+#
+
+# ------------------------------------------
+# CONFIGURATION DETAILS
+# ------------------------------------------
+# Refer to http://docs.aws.amazon.com/AmazonCloudWatch/latest/DeveloperGuide/AgentReference.html for details.
+
+[general]
+# Path to the CloudWatch Logs agent's state file. The agent uses this file to maintain
+# client side state across its executions.
+state_file = /var/awslogs/state/agent-state
+
+## Each log file is defined in its own section. The section name doesn't
+## matter as long as its unique within this file.
+#[kern.log]
+#
+## Path of log file for the agent to monitor and upload.
+#file = /var/log/kern.log
+#
+## Name of the destination log group.
+#log_group_name = kern.log
+#
+## Name of the destination log stream. You may use {hostname} to use target machine's hostname.
+#log_stream_name = {instance_id} # Defaults to ec2 instance id
+#
+## Format specifier for timestamp parsing. Here are some sample formats:
+## Use '%b %d %H:%M:%S' for syslog (Apr 24 08:38:42)
+## Use '%d/%b/%Y:%H:%M:%S' for apache log (10/Oct/2000:13:55:36)
+## Use '%Y-%m-%d %H:%M:%S' for rails log (2008-09-08 11:52:54)
+#datetime_format = %b %d %H:%M:%S # Specification details in the table below.
+#
+## A batch is buffered for buffer-duration amount of time or 32KB of log events.
+## Defaults to 5000 ms and its minimum value is 5000 ms.
+#buffer_duration = 5000
+#
+# Use 'end_of_file' to start reading from the end of the file.
+# Use 'start_of_file' to start reading from the beginning of the file.
+#initial_position = start_of_file
+#
+## Encoding of file
+#encoding = utf-8 # Other supported encodings include: ascii, latin-1
+#
+#
+#
+# Following table documents the detailed datetime format specification:
+# ----------------------------------------------------------------------------------------------------------------------
+# Directive     Meaning                                                                                 Example
+# ----------------------------------------------------------------------------------------------------------------------
+# %a            Weekday as locale's abbreviated name.                                                   Sun, Mon, ..., Sat (en_US)
+# ----------------------------------------------------------------------------------------------------------------------
+#  %A           Weekday as locale's full name.                                                          Sunday, Monday, ..., Saturday (en_US)
+# ----------------------------------------------------------------------------------------------------------------------
+#  %w           Weekday as a decimal number, where 0 is Sunday and 6 is Saturday.                       0, 1, ..., 6
+# ----------------------------------------------------------------------------------------------------------------------
+#  %d           Day of the month as a zero-padded decimal numbers.                                      01, 02, ..., 31
+# ----------------------------------------------------------------------------------------------------------------------
+#  %b           Month as locale's abbreviated name.                                                     Jan, Feb, ..., Dec (en_US)
+# ----------------------------------------------------------------------------------------------------------------------
+#  %B           Month as locale's full name.                                                            January, February, ..., December (en_US)
+# ----------------------------------------------------------------------------------------------------------------------
+#  %m           Month as a zero-padded decimal number.                                                  01, 02, ..., 12
+# ----------------------------------------------------------------------------------------------------------------------
+#  %y           Year without century as a zero-padded decimal number.                                   00, 01, ..., 99
+# ----------------------------------------------------------------------------------------------------------------------
+#  %Y           Year with century as a decimal number.                                                  1970, 1988, 2001, 2013
+# ----------------------------------------------------------------------------------------------------------------------
+#  %H           Hour (24-hour clock) as a zero-padded decimal number.                                   00, 01, ..., 23
+# ----------------------------------------------------------------------------------------------------------------------
+#  %I           Hour (12-hour clock) as a zero-padded decimal numbers.                                  01, 02, ..., 12
+# ----------------------------------------------------------------------------------------------------------------------
+#  %p           Locale's equivalent of either AM or PM.                                                 AM, PM (en_US)
+# ----------------------------------------------------------------------------------------------------------------------
+#  %M           Minute as a zero-padded decimal number.                                                 00, 01, ..., 59
+# ----------------------------------------------------------------------------------------------------------------------
+#  %S           Second as a zero-padded decimal numbers.                                                00, 01, ..., 59
+# ----------------------------------------------------------------------------------------------------------------------
+#  %f           Microsecond as a decimal number, zero-padded on the left.                               000000, 000001, ..., 999999
+# ----------------------------------------------------------------------------------------------------------------------
+#  %z           UTC offset in the form +HHMM or -HHMM (empty string if the the object is naive).        (empty), +0000, -0400, +1030
+# ----------------------------------------------------------------------------------------------------------------------
+#  %j           Day of the year as a zero-padded decimal number.                                        001, 002, ..., 365
+# ----------------------------------------------------------------------------------------------------------------------
+#  %U           Week number of the year (Sunday as the first day of the week) as a zero padded          00, 01, ..., 53
+#               decimal number. All days in a new year preceding the first Sunday are considered
+#               to be in week 0.
+# ----------------------------------------------------------------------------------------------------------------------
+#  %W           Week number of the year (Monday as the first day of the week) as a decimal number.      00, 01, ..., 53
+#               All days in a new year preceding the first Monday are considered to be in week 0.
+# ----------------------------------------------------------------------------------------------------------------------
+#  %c           Locale's appropriate date and time representation.                                      Tue Aug 16 21:30:00 1988 (en_US)
+# ----------------------------------------------------------------------------------------------------------------------
+
+
+[/var/log/messages]
+datetime_format = %b %d %H:%M:%S
+file = /var/log/messages
+buffer_duration = 5000
+log_stream_name = {instance_id}
+initial_position = end_of_file
+log_group_name = /var/log/messages
+
+[/var/log/secure]
+datetime_format = %b %d %H:%M:%S
+file = /var/log/secure
+buffer_duration = 5000
+log_stream_name = {instance_id}
+initial_position = start_of_file
+log_group_name = /var/log/secure
+
+[Jboss_Access_Log]
+datetime_format = %d/%b/%Y:%H:%M:%S
+file = /u01/jboss/jboss-eap-7.0/standalone/log/access*.log
+buffer_duration = 5000
+log_stream_name = {instance_id}
+initial_position = start_of_file
+log_group_name = {{ env_name }}_jboss_access
+
+[jboss_server]
+datetime_format = %Y-%m-%d %H:%M:%S,%f
+file = /u01/jboss/jboss-eap-7.0/standalone/log/server.log*
+buffer_duration = 5000
+log_stream_name = {instance_id}
+initial_position = start_of_file
+log_group_name = /bfs/{{ env_name_std }}/data-server/access
+
+[bfs_app_access]
+datetime_format = %Y-%m-%dT%H:%M:%S.%f%z
+file = /u01/jboss/bluebutton-server-app-log-access.json
+buffer_duration = 5000
+log_stream_name = {instance_id}
+initial_position = start_of_file
+log_group_name = /bfs/{{ env_name_std }}/data-server/access
+
+[bfs_app_database_query]
+datetime_format = %Y-%m-%dT%H:%M:%S.%f%z
+file = /u01/jboss/bluebutton-server-app-log-database.json
+buffer_duration = 5000
+log_stream_name = {instance_id}
+initial_position = start_of_file
+log_group_name = /bfs/{{ env_name_std }}/data-server/database
+
+[bfs_app_message_txt]
+datetime_format = %Y-%m-%d %H:%M:%S,%f
+file = /u01/jboss/bluebutton-server-app.log
+buffer_duration = 5000
+log_stream_name = {instance_id}
+initial_position = start_of_file
+log_group_name = /bfs/{{ env_name_std }}/data-server/message.txt
+
+[bfs_app_message_ndjson]
+datetime_format = %Y-%m-%dT%H:%M:%S.%f%z
+file = /u01/jboss/bluebutton-server-app-log.json
+buffer_duration = 5000
+log_stream_name = {instance_id}
+initial_position = start_of_file
+log_group_name = /bfs/{{ env_name_std }}/data-server/message.json
+
+[bfs_app_gc]
+datetime_format = %Y-%m-%dT%H:%M:%S.%f%z
+file = /u01/jboss/bluebutton-server-app-log.json
+buffer_duration = 5000
+log_stream_name = {instance_id}
+initial_position = start_of_file
+log_group_name = /bfs/{{ env_name_std }}/data-server/message.json
+multi_line_start_pattern = ^[^\d]

--- a/templates/awslogs.conf.data-server.j2
+++ b/templates/awslogs.conf.data-server.j2
@@ -149,7 +149,7 @@ file = /u01/jboss/jboss-eap-7.0/standalone/log/server.log*
 buffer_duration = 5000
 log_stream_name = {instance_id}
 initial_position = start_of_file
-log_group_name = /bfs/{{ env_name_std }}/data-server/access
+log_group_name = /bfd/{{ env_name_std }}/data-server/access
 
 [bfs_app_access]
 datetime_format = %Y-%m-%dT%H:%M:%S.%f%z
@@ -157,7 +157,7 @@ file = /u01/jboss/bluebutton-server-app-log-access.json
 buffer_duration = 5000
 log_stream_name = {instance_id}
 initial_position = start_of_file
-log_group_name = /bfs/{{ env_name_std }}/data-server/access
+log_group_name = /bfd/{{ env_name_std }}/data-server/access
 
 [bfs_app_database_query]
 datetime_format = %Y-%m-%dT%H:%M:%S.%f%z
@@ -165,7 +165,7 @@ file = /u01/jboss/bluebutton-server-app-log-database.json
 buffer_duration = 5000
 log_stream_name = {instance_id}
 initial_position = start_of_file
-log_group_name = /bfs/{{ env_name_std }}/data-server/database
+log_group_name = /bfd/{{ env_name_std }}/data-server/database
 
 [bfs_app_message_txt]
 datetime_format = %Y-%m-%d %H:%M:%S,%f
@@ -173,7 +173,7 @@ file = /u01/jboss/bluebutton-server-app.log
 buffer_duration = 5000
 log_stream_name = {instance_id}
 initial_position = start_of_file
-log_group_name = /bfs/{{ env_name_std }}/data-server/message.txt
+log_group_name = /bfd/{{ env_name_std }}/data-server/message.txt
 
 [bfs_app_message_ndjson]
 datetime_format = %Y-%m-%dT%H:%M:%S.%f%z
@@ -181,7 +181,7 @@ file = /u01/jboss/bluebutton-server-app-log.json
 buffer_duration = 5000
 log_stream_name = {instance_id}
 initial_position = start_of_file
-log_group_name = /bfs/{{ env_name_std }}/data-server/message.json
+log_group_name = /bfd/{{ env_name_std }}/data-server/message.json
 
 [bfs_app_gc]
 datetime_format = %Y-%m-%dT%H:%M:%S.%f%z
@@ -189,5 +189,5 @@ file = /u01/jboss/bluebutton-server-app-log.json
 buffer_duration = 5000
 log_stream_name = {instance_id}
 initial_position = start_of_file
-log_group_name = /bfs/{{ env_name_std }}/data-server/message.json
+log_group_name = /bfd/{{ env_name_std }}/data-server/message.json
 multi_line_start_pattern = ^[^\d]


### PR DESCRIPTION
The `awslogs` service is already installed and configured (by hand) on the Data Server and Data Pipeline systems, so this just updates the config.

Eventually, we should consider switching to the newer "unified CloudWatch agent", but I want to start by just getting what we have uploading.

https://jira.cms.gov/browse/BLUEBUTTON-947